### PR TITLE
just tunnel

### DIFF
--- a/docker/devbox.nginx.conf
+++ b/docker/devbox.nginx.conf
@@ -11,7 +11,7 @@ upstream reload-live {
 }
 
 server {
-    server_name live-ol.local *.kll.io;
+    server_name live-ol.local live-ol.tunnel;
     access_log /var/log/nginx/access.log vhost;
     listen 80 ;
     location / {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -137,3 +137,13 @@ services:
       - --timestamp
     restart: on-failure
     stop_grace_period: 15s
+
+  cftunnel:
+    profiles:
+      - cftunnel
+    image: cloudflare/cloudflared:latest
+    command:
+      - tunnel
+      - --no-autoupdate
+      - --http-host-header=live-ol.tunnel
+      - --url=http://nginx-proxy:80

--- a/justfile
+++ b/justfile
@@ -29,6 +29,9 @@ watch-css:
     # todo gfi: combine with watch recipe  
     npm run watch-css
 
+tunnel:
+  cd docker && docker-compose run --rm cftunnel
+
 
 ORDA := "ord -r --wallet alice --rpc-url bitcoin-core:18443/wallet/alice"
 _fixtures:


### PR DESCRIPTION
- quickly show off your current branch with
```bash
just tunnel
```
- requests a a new `*.trycloudflare.com` sub-domain every time
- differentiate request to nginx-proxy by origin `*.local` and `*.tunnel`
- cancel the tunnel with `Crtl+C`