### PR TITLE
VSCode: Add rust-analyzer settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": ["ssr"]
+}


### PR DESCRIPTION
In VSCode `rust-analyzer` needs an additional information about the feature to use. In other case VSCode will inactivate some code (mostly in `backend` folder) because of different features (`ssr` - backend binary, `hydrate` - frontend library). This setting is needed for development and for VSCode users only. 