### PR TITLE
Default to users mainnet node

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # warning: dotenv crate doesn't override
 
-# uncomment with :8332 to use your own mempool
+# uncomment 2 lines below below to use the docker regtest node
 # CORE_URL=127.0.0.1:18332
 # CORE_COOKIE=docker/bitcoin.cookie
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 # warning: dotenv crate doesn't override
 
 # uncomment 2 lines below below to use the docker regtest node
-# CORE_URL=127.0.0.1:18332
+# CORE_URL=127.0.0.1:18443
 # CORE_COOKIE=docker/bitcoin.cookie
 
 # if user is set, it takes precedent over the .cookie auth version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be3be809c18e089de43bdc504652bb2bc473fca8756131f8689db8cf079ba9"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2139,7 @@ dependencies = [
  "console-subscriber",
  "console_error_panic_hook",
  "console_log",
+ "directories",
  "dotenv",
  "futures 0.3.28",
  "gloo-net 0.2.6 (git+https://github.com/rustwasm/gloo)",
@@ -2546,6 +2567,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ cfg-if = "1"
 console-subscriber = { version = "0.1.8", optional = true }
 console_error_panic_hook = "0.1"
 console_log = "1.0"
+directories = { version = "5.0.0", optional = true }
 dotenv = { version = "0.15.0", optional = true }
 futures = "0.3"
 gloo-net = { git = "https://github.com/rustwasm/gloo" }
@@ -68,6 +69,7 @@ ssr = [
   "dep:bitcoincore-rpc",
   "dep:console-subscriber",
   "dep:dotenv",
+  "dep:directories",
   "dep:headers",
   "dep:hex",
   "dep:leptos_axum",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ cd live--ordilabs
 just install
 ```
 
+### inscription watching
+
+Run a local instance of Ordi Live after starting bitcoin core:
+
+```bash
+just watch
+```
+
+Open a browser `http:://127.0.0.1:3000` to new inscriptions hitting your mempool in real time
+
 ### developing
 
 All micro-services are managed with 2 simple commands
@@ -37,9 +47,10 @@ just run-services
 # just clean-services
 ```
 
-Once they are running, you can start developing
+Once they are running, you can start developing.
 
 ```bash
+cp .env.sample .env # and uncomment the relevant lines
 just watch # for changes, recompile rust/css, refresh frontend
 ```
 
@@ -71,8 +82,9 @@ see more commands with `just -l`
 ```bash
 Error response from daemon: invalid IP address in add-host: ""
 error: Recipe `run-services` failed on line 34 with exit code 1
-``` 
-*Quick fix (manually):* 
+```
+
+*Quick fix (manually):*
 
 - In `just` file override `run-services` as follow
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ async fn sse_handler(
 #[cfg(feature = "ssr")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  // load the .env file located in CWD or its parents in sequence.
   dotenv::dotenv().ok();
 
   let console_layer = console_subscriber::spawn();
@@ -218,6 +219,8 @@ pub async fn spawn_server_ticks() {
 
   // todo: print more relevant config stuff
   tracing::info!(?backend_bitcoin_core);
+  let block_count = backend_bitcoin_core.get_block_count();
+  tracing::info!(?block_count);
 
   let mut interval = tokio::time::interval(std::time::Duration::from_millis(3142));
   loop {


### PR DESCRIPTION
Quicker setup: A normal user can now without configuration `just watch` their own node's mempool for mainnet inscriptions.

Only when you want to become a developer on the project you need to copy the `.env.sample` file and build the containers and `just run-services`

closes #74