### PR TITLE
Show block height in footer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,6 +2161,7 @@ dependencies = [
  "reqwest",
  "rusty-hook",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ord-labs = { version = "0.1.0", git = "https://github.com/ordilabs/ord-labs.git"
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.11.16", optional = true, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1" }
 thiserror = "1.0.40"
 tokio = { version = "1.27.0", features = ["full"], optional = true }
 tokio-stream = { version = "0.1.12", optional = true }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "live--ordilabs",
+  "name": "live",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/app.rs
+++ b/src/app.rs
@@ -112,6 +112,11 @@ pub fn App(cx: Scope) -> impl IntoView {
 
     let mut source = gloo_net::eventsource::futures::EventSource::new("/api/events")
       .expect("couldn't connect to SSE stream");
+
+    // Note:
+    // All data of subscriptions are stringified JSON (similar to `JSON.stringify` in JS) - see implementation in `main.rs -> sse_handler`
+    // And needs to be deserialized `serde_json::from_str` (similar to `JSON.parse` in JS)
+
     let inscription = create_signal_from_stream(
       cx,
       source.subscribe("inscription").unwrap().map(|value| {

--- a/src/app/components/layout.rs
+++ b/src/app/components/layout.rs
@@ -55,8 +55,22 @@ pub fn Header(cx: Scope) -> impl IntoView {
 }
 
 #[component]
-pub fn Footer(cx: Scope, block_value: ReadSignal<Option<String>>) -> impl IntoView {
-  let block = block_value;
+pub fn Footer(
+  cx: Scope,
+  block_rs: ReadSignal<Option<u64>>,
+  time_rs: ReadSignal<Option<std::time::SystemTime>>,
+) -> impl IntoView {
+  let block = block_rs;
+
+  // TODO (@sectore) Remove it - just for testing serialization/deserialization LiveEvents (see #100)
+  let time = time_rs;
+  let current = move || match time.get() {
+    None => String::from("--"),
+    Some(v) => match v.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+      Err(_) => String::from("invalid"),
+      Ok(v) => format!("{}", v.as_secs()),
+    },
+  };
 
   view! { cx,
     <footer class="bg-white dark:bg-slate-800">
@@ -78,6 +92,8 @@ pub fn Footer(cx: Scope, block_value: ReadSignal<Option<String>>) -> impl IntoVi
             ></path>
           </svg>
           {block}
+          " | "
+          {current}
         </div>
         <div class="md:flex md:items-center my-2 md:my-0">
           <div class="flex justify-center space-x-4">

--- a/src/app/components/layout.rs
+++ b/src/app/components/layout.rs
@@ -22,7 +22,6 @@ pub fn Header(cx: Scope) -> impl IntoView {
                   alt="Ordilabs"
                 />
               </div>
-              <div class="hidden md:ml-6 md:flex md:items-center md:space-x-4"></div>
             </div>
             <div class="flex items-center">
               <div class="flex-shrink-0">
@@ -47,9 +46,6 @@ pub fn Header(cx: Scope) -> impl IntoView {
                 </a>
               </div>
               <ThemeToggle/>
-              <div class="hidden md:ml-4 md:flex md:flex-shrink-0 md:items-center">
-                <div class="relative ml-3"></div>
-              </div>
             </div>
           </div>
         </div>
@@ -59,36 +55,55 @@ pub fn Header(cx: Scope) -> impl IntoView {
 }
 
 #[component]
-pub fn Footer(cx: Scope) -> impl IntoView {
+pub fn Footer(cx: Scope, block_value: ReadSignal<Option<String>>) -> impl IntoView {
+  let block = block_value;
+
   view! { cx,
     <footer class="bg-white dark:bg-slate-800">
-      <div class="mx-auto max-w-7xl py-12 px-6 md:flex md:items-center md:justify-between lg:px-8">
-        <div class="flex justify-center space-x-6 md:order-2">
-          <a
-            href="https://twitter.com/OrdiLabs_org"
-            class="text-gray-400 hover:text-gray-500 dark:text-gray-100"
+      <div class="mx-auto max-w-7xl flex flex-col-reverse md:flex-row md:justify-between px-4 sm:px-6 lg:px-8 py-2 md:py-6">
+        <div class="flex justify-center md:items-center mb-2 md:mb-0 text-gray-400 dark:text-gray-400">
+          <svg
+            class="h-6 w-6 mr-1"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <span class="sr-only">"Twitter"</span>
-            <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
-            </svg>
-          </a>
-          <a
-            href="https://github.com/ordilabs/live"
-            class="text-gray-400 hover:text-gray-500 dark:text-gray-100"
-          >
-            <span class="sr-only">"GitHub"</span>
-            <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                fill-rule="evenodd"
-                d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-                clip-rule="evenodd"
-              ></path>
-            </svg>
-          </a>
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+            ></path>
+          </svg>
+          {block}
         </div>
-        <div class="mt-8 md:order-1 md:mt-0">
-          <p class="text-center text-xs leading-5 text-gray-500 dark:text-gray-100"></p>
+        <div class="md:flex md:items-center my-2 md:my-0">
+          <div class="flex justify-center space-x-4">
+            <a
+              href="https://twitter.com/OrdiLabs_org"
+              class="text-gray-400 hover:text-gray-500 dark:text-gray-100"
+            >
+              <span class="sr-only">"Twitter"</span>
+              <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
+              </svg>
+            </a>
+            <a
+              href="https://github.com/ordilabs/live"
+              class="text-gray-400 hover:text-gray-500 dark:text-gray-100"
+            >
+              <span class="sr-only">"GitHub"</span>
+              <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clip-rule="evenodd"
+                ></path>
+              </svg>
+            </a>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/backend/bitcoin_core.rs
+++ b/src/backend/bitcoin_core.rs
@@ -48,7 +48,7 @@ impl BitcoinCore {
     }
   }
 
-  pub fn get_block_count(&self) -> u64 {
+  pub async fn get_block_count(&self) -> u64 {
     let client = bitcoincore_rpc::Client::new(&self.root, self.auth.clone()).unwrap();
     client.get_block_count().unwrap()
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,19 +106,19 @@ async fn sse_handler(
   })
   .chain(EVENT_CHANNEL.clone())
   .map(|event| match event {
-    LiveEvent::NewInscription(data) | LiveEvent::RandomInscription(data) => Ok(
-      Event::default()
-        .event("inscription")
-        .json_data(data.as_str())
-        .unwrap(),
-    ),
-    LiveEvent::MempoolInfo(data) => Ok(
-      Event::default()
-        .event("info")
-        .json_data(data.as_str())
-        .unwrap(),
-    ),
-    LiveEvent::BlockCount(data) => Ok(Event::default().event("block").json_data(&data).unwrap()),
+    LiveEvent::NewInscription(data) | LiveEvent::RandomInscription(data) => {
+      Ok(Event::default().event("inscription").data(data.as_str()))
+    }
+    LiveEvent::MempoolInfo(data) => Ok(Event::default().event("info").data(data.as_str())),
+    LiveEvent::BlockCount(data) => {
+      let s = serde_json::to_string(&data).unwrap();
+      Ok(Event::default().event("block").data(&s.as_str()))
+    }
+    // TODO (@sectore) Remove it - just for testing serialization/deserialization LiveEvents (see #100)
+    LiveEvent::ServerTime(data) => {
+      let s = serde_json::to_string(&data).unwrap();
+      Ok(Event::default().event("time").data(&s.as_str()))
+    }
   });
 
   Sse::new(stream).keep_alive(

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,10 +106,17 @@ async fn sse_handler(
   })
   .chain(EVENT_CHANNEL.clone())
   .map(|event| match event {
+    // Note:
+    // Any data sent over wire needs to be serialized into a stringified JSON using `serde_json::to_string` (similar to `JSON.stringify` in JS)
+    // It will be deserialized at frontend using `serde_json::from_str` (similar to `JSON.parse` in JS) - see implementation in `App.rs -> App`
     LiveEvent::NewInscription(data) | LiveEvent::RandomInscription(data) => {
-      Ok(Event::default().event("inscription").data(data.as_str()))
+      let s = serde_json::to_string(&data).unwrap();
+      Ok(Event::default().event("inscription").data(&s.as_str()))
     }
-    LiveEvent::MempoolInfo(data) => Ok(Event::default().event("info").data(data.as_str())),
+    LiveEvent::MempoolInfo(data) => {
+      let s = serde_json::to_string(&data).unwrap();
+      Ok(Event::default().event("info").data(&s.as_str()))
+    }
     LiveEvent::BlockCount(data) => {
       let s = serde_json::to_string(&data).unwrap();
       Ok(Event::default().event("block").data(&s.as_str()))

--- a/src/server_actions.rs
+++ b/src/server_actions.rs
@@ -60,8 +60,11 @@ pub(crate) async fn tick_bitcoin_core(
   let block_count = backend.get_block_count().await;
   tracing::info!(?block_count);
 
-  // let t = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH);
-  // let event = LiveEvent::BlockCount(t.unwrap().as_secs_f64().trunc() as u64);
+  // TODO (@sectore) Remove it - just for testing serialization/deserialization LiveEvents (see #100)
+  let t = std::time::SystemTime::now();
+  let event = LiveEvent::ServerTime(t);
+  _ = EVENT_CHANNEL.send(&event).await;
+
   let event = LiveEvent::BlockCount(block_count);
   _ = EVENT_CHANNEL.send(&event).await;
 

--- a/src/server_actions.rs
+++ b/src/server_actions.rs
@@ -1,6 +1,7 @@
 use super::*;
 use std::collections::HashMap;
 extern crate rand;
+
 use rand::seq::IteratorRandom;
 
 use ord_labs::{Inscription, Media};
@@ -55,8 +56,19 @@ pub(crate) async fn tick_bitcoin_core(
   backend: &BitcoinCore,
   ordipool: &mut HashMap<String, Option<Inscription>>,
 ) {
+  // Current block
+  let block_count = backend.get_block_count().await;
+  tracing::info!(?block_count);
+
+  // let t = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH);
+  // let event = LiveEvent::BlockCount(t.unwrap().as_secs_f64().trunc() as u64);
+  let event = LiveEvent::BlockCount(block_count);
+  _ = EVENT_CHANNEL.send(&event).await;
+
   let tick_start = std::time::Instant::now();
 
+  // TODO(@sectore) Disable `recent` call temporarily - it breaks on mainnet
+  // let mpr: MempoolRecent = Vec::default();
   let mpr = backend.recent().await.ok();
   let mpr = mpr.unwrap_or_default();
 


### PR DESCRIPTION
## Changes

- [x] Stream `block height` via `LiveEvent::BlockCount` from back- to frontend
- [x] Introduce `stream_values: StreamValues`  (to get rid of `multiplayer_value`) in `App`
- [x] Update `sse_handler` to send stream data as `JSON` (instead of string) over wire to provide more complex data in future. 
- [x] Add a more "complex data" example for sending `SystemTime` via `LiveEvent::ServerTime` over the wire

## Preview
[Screencast from 24.04.2023 17:39:26.webm](https://user-images.githubusercontent.com/47693/234047708-8cedc7da-fad1-4728-8d71-f881a631c4f6.webm)

