### PR TITLE
Inscription detail template + Routes + Refactoring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+    "editor.formatOnSave": true
+  },
   "rust-analyzer.cargo.features": ["ssr"],
   "tailwindCSS.includeLanguages": {
     "rust": "html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,3 +149,11 @@ lib-features = ["hydrate"]
 #
 # Optional. Defaults to false.
 lib-default-features = false
+
+lib-profile-release = "wasm-release"
+
+[profile.wasm-release]
+inherits = "release"
+opt-level = 'z'
+lto = true
+codegen-units = 1

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,7 +36,7 @@ lazy_static::lazy_static! {
 pub fn App(cx: Scope) -> impl IntoView {
   provide_meta_context(cx);
   provide_theme_context(cx);
-  provide_api_context(cx);
+  provide_stream_context(cx);
 
   let theme_ctx = use_context::<ThemeContext>(cx).expect("Failed to get ThemeContext");
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,30 +1,18 @@
 use crate::app::components::*;
 use crate::app::providers::*;
+use crate::app::routes::*;
+
 use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
 
 mod components;
+pub mod functions;
 mod providers;
-
-#[cfg(feature = "ssr")]
-use std::sync::atomic::{AtomicI32, Ordering};
-use std::time::SystemTime;
+mod routes;
 
 #[cfg(feature = "ssr")]
 use broadcaster::BroadcastChannel;
-
-#[cfg(feature = "ssr")]
-pub fn register_server_functions() {
-  _ = GetServerCount::register();
-  _ = AdjustServerCount::register();
-  _ = ClearServerCount::register();
-  _ = GetLastInscription::register();
-  _ = SetDarkTheme::register();
-}
-
-#[cfg(feature = "ssr")]
-static COUNT: AtomicI32 = AtomicI32::new(0);
 
 #[cfg(feature = "ssr")]
 #[derive(Clone, Debug)]
@@ -43,165 +31,14 @@ lazy_static::lazy_static! {
     pub static ref INSCRIPTION_CHANNEL: BroadcastChannel<String> = BroadcastChannel::new();
     pub static ref EVENT_CHANNEL: BroadcastChannel<LiveEvent> = BroadcastChannel::new();
 }
-// "/api" is an optional prefix that allows you to locate server functions wherever you'd like on the server
-#[server(GetServerCount, "/api")]
-pub async fn get_server_count() -> Result<i32, ServerFnError> {
-  Ok(COUNT.load(Ordering::Relaxed))
-}
-
-#[server(GetLastInscription, "/api")]
-pub async fn get_last_inscription() -> Result<String, ServerFnError> {
-  Ok("".to_string())
-}
-
-#[server(AdjustServerCount, "/api")]
-pub async fn adjust_server_count(delta: i32, msg: String) -> Result<i32, ServerFnError> {
-  let new = COUNT.load(Ordering::Relaxed) + delta;
-  COUNT.store(new, Ordering::Relaxed);
-  _ = COUNT_CHANNEL.send(&new).await;
-  println!("message = {:?}", msg);
-  Ok(new)
-}
-
-#[server(ClearServerCount, "/api")]
-pub async fn clear_server_count() -> Result<i32, ServerFnError> {
-  COUNT.store(0, Ordering::Relaxed);
-  _ = COUNT_CHANNEL.send(&0).await;
-  Ok(0)
-}
-
-#[server(SetDarkTheme, "/api")]
-pub async fn set_dark_theme(
-  #[allow(unused_variables)] cx: Scope,
-  is_dark: bool,
-) -> Result<bool, ServerFnError> {
-  use axum::http::header::{HeaderMap, HeaderValue, SET_COOKIE};
-  use leptos_axum::{ResponseOptions, ResponseParts};
-
-  let response =
-    use_context::<ResponseOptions>(cx).expect("to have leptos_axum::ResponseOptions provided");
-  let mut response_parts = ResponseParts::default();
-  let mut headers = HeaderMap::new();
-  headers.insert(
-    SET_COOKIE,
-    HeaderValue::from_str(&format!("darkmode={is_dark}; Path=/")).expect("to create header value"),
-  );
-  response_parts.headers = headers;
-
-  response.overwrite(response_parts);
-  Ok(is_dark)
-}
-
-#[allow(dead_code)]
-struct StreamValues {
-  inscription: ReadSignal<Option<String>>,
-  info: ReadSignal<Option<String>>,
-  block: ReadSignal<Option<u64>>,
-  time: ReadSignal<Option<SystemTime>>,
-}
 
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {
   provide_meta_context(cx);
   provide_theme_context(cx);
-
-  // #[cfg(feature = "ssr")]
-  #[cfg(not(feature = "ssr"))]
-  let stream_values = {
-    use futures::StreamExt;
-
-    let mut source = gloo_net::eventsource::futures::EventSource::new("/api/events")
-      .expect("couldn't connect to SSE stream");
-
-    // Note:
-    // All data of subscriptions are stringified JSON (similar to `JSON.stringify` in JS) - see implementation in `main.rs -> sse_handler`
-    // And needs to be deserialized `serde_json::from_str` (similar to `JSON.parse` in JS)
-
-    let inscription = create_signal_from_stream(
-      cx,
-      source.subscribe("inscription").unwrap().map(|value| {
-        let s = value
-          .expect("no message event")
-          .1
-          .data()
-          .as_string()
-          .expect("expected string value");
-
-        serde_json::from_str::<String>(s.as_str()).expect("expected String value")
-      }),
-    );
-
-    let info = create_signal_from_stream(
-      cx,
-      source.subscribe("info").unwrap().map(|value| {
-        let s = value
-          .expect("no message event")
-          .1
-          .data()
-          .as_string()
-          .expect("expected string value");
-
-        serde_json::from_str::<String>(s.as_str()).expect("expected String value")
-      }),
-    );
-
-    let block = create_signal_from_stream(
-      cx,
-      source.subscribe("block").unwrap().map(|value| {
-        let s = value
-          .expect("no message event")
-          .1
-          .data()
-          .as_string()
-          .expect("expected string value");
-        serde_json::from_str::<u64>(s.as_str()).expect("expected u64 value")
-      }),
-    );
-
-    // TODO (@sectore) Remove it - just for testing serialization/deserialization LiveEvents (see #100)
-    let time = create_signal_from_stream(
-      cx,
-      source.subscribe("time").unwrap().map(|value| {
-        let s = value
-          .expect("no message event")
-          .1
-          .data()
-          .as_string()
-          .expect("expected string value");
-        serde_json::from_str::<SystemTime>(s.as_str()).expect("expected SystemTime value")
-      }),
-    );
-
-    on_cleanup(cx, move || source.close());
-
-    StreamValues {
-      inscription,
-      info,
-      block,
-      time,
-    }
-  };
-
-  #[cfg(feature = "ssr")]
-  let stream_values = StreamValues {
-    inscription: create_signal(cx, None::<String>).0,
-    info: create_signal(cx, None::<String>).0,
-    block: create_signal(cx, None::<u64>).0,
-    time: create_signal(cx, None::<SystemTime>).0,
-  };
-
-  let StreamValues {
-    inscription,
-    info,
-    block,
-    time,
-  } = stream_values;
-
-  let initial_items: Vec<_> = (0..6).map(|n| format!("punk_{}.webp", n)).collect();
+  provide_api_context(cx);
 
   let theme_ctx = use_context::<ThemeContext>(cx).expect("Failed to get ThemeContext");
-
-  // let output_name = std::env::var("LEPTOS_OUTPUT_NAME").unwrap();
 
   view! { cx,
     <Router>
@@ -220,18 +57,23 @@ pub fn App(cx: Scope) -> impl IntoView {
           <Header/>
           <div class="flex flex-1 items-stretch overflow-hidden">
             <main class="flex-1 overflow-y-auto">
-              <div class="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
-                <div class="flex">
-                  <h1 class="flex-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
-                    "Live unconfirmed inscriptions"
-                  </h1>
-                </div>
-                <div class="text-xs text-gray-900 dark:text-gray-100">{info}</div>
-                <LiveGrid initial_items multiplayer_value=inscription/>
-              </div>
+              <Routes>
+                <Route
+                  path="/"
+                  view=|cx| {
+                      view! { cx, <Home/> }
+                  }
+                />
+                <Route
+                  path="inscription/:id"
+                  view=|cx| {
+                      view! { cx, <Inscription/> }
+                  }
+                />
+              </Routes>
             </main>
           </div>
-          <Footer block_rs=block time_rs=time/>
+          <Footer/>
         </div>
       </body>
     </Router>

--- a/src/app/components/layout.rs
+++ b/src/app/components/layout.rs
@@ -33,7 +33,7 @@ pub fn Header(cx: Scope) -> impl IntoView {
                 <a
                   href="https://github.com/ordilabs/live"
                   target="_blank"
-                  class="relative inline-flex items-center gap-x-1.5 rounded-md bg-red-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500"
+                  class="relative inline-flex items-center gap-x-1.5 rounded-md ease bg-red-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500"
                 >
                   <svg
                     class="-ml-0.5 h-5 w-5"
@@ -103,7 +103,7 @@ pub fn Footer(cx: Scope) -> impl IntoView {
           <div class="flex justify-center space-x-4">
             <a
               href="https://twitter.com/OrdiLabs_org"
-              class="text-gray-400 hover:text-gray-500 dark:text-gray-100"
+              class="text-gray-400 hover:text-gray-500 dark:text-gray-100 ease hover:bg-gray-200 p-2 rounded-full dark:hover:bg-white/20 "
             >
               <span class="sr-only">"Twitter"</span>
               <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -112,7 +112,7 @@ pub fn Footer(cx: Scope) -> impl IntoView {
             </a>
             <a
               href="https://github.com/ordilabs/live"
-              class="text-gray-400 hover:text-gray-500 dark:text-gray-100"
+              class="text-gray-400 hover:text-gray-500 dark:text-gray-100 ease hover:bg-gray-200 p-2 rounded-full dark:hover:bg-white/20"
             >
               <span class="sr-only">"GitHub"</span>
               <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/app/components/layout.rs
+++ b/src/app/components/layout.rs
@@ -1,5 +1,6 @@
 use crate::app::components::{ThemeToggle, ThemeToggleProps};
 use leptos::*;
+use leptos_router::*;
 
 use crate::app::providers::*;
 
@@ -8,21 +9,23 @@ pub fn Header(cx: Scope) -> impl IntoView {
   view! { cx,
     <header class="w-full">
       <nav class="bg-gray-800">
-        <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div class="content">
           <div class="flex h-16 justify-between">
             <div class="flex">
               <div class="-ml-2 mr-2 flex items-center md:hidden"></div>
               <div class="flex flex-shrink-0 items-center">
-                <img
-                  class="block h-8 w-auto lg:hidden"
-                  src="/ordilabs-logo-name-h.svg"
-                  alt="Ordilabs"
-                />
-                <img
-                  class="hidden h-8 w-auto lg:block"
-                  src="/ordilabs-logo-name-h.svg"
-                  alt="Ordilabs"
-                />
+                <A href="/">
+                  <img
+                    class="block h-8 w-auto lg:hidden"
+                    src="/ordilabs-logo-name-h.svg"
+                    alt="Ordilabs"
+                  />
+                  <img
+                    class="hidden h-8 w-auto lg:block"
+                    src="/ordilabs-logo-name-h.svg"
+                    alt="Ordilabs"
+                  />
+                </A>
               </div>
             </div>
             <div class="flex items-center">
@@ -75,7 +78,7 @@ pub fn Footer(cx: Scope) -> impl IntoView {
 
   view! { cx,
     <footer class="bg-white dark:bg-slate-800">
-      <div class="mx-auto max-w-7xl flex flex-col-reverse md:flex-row md:justify-between px-4 sm:px-6 lg:px-8 py-2 md:py-6">
+      <div class="content flex flex-col-reverse md:flex-row md:justify-between py-2 md:py-6">
         <div class="flex justify-center md:items-center mb-2 md:mb-0 text-gray-400 dark:text-gray-400">
           <svg
             class="h-6 w-6 mr-1"

--- a/src/app/components/layout.rs
+++ b/src/app/components/layout.rs
@@ -1,6 +1,8 @@
 use crate::app::components::{ThemeToggle, ThemeToggleProps};
 use leptos::*;
 
+use crate::app::providers::*;
+
 #[component]
 pub fn Header(cx: Scope) -> impl IntoView {
   view! { cx,
@@ -55,15 +57,14 @@ pub fn Header(cx: Scope) -> impl IntoView {
 }
 
 #[component]
-pub fn Footer(
-  cx: Scope,
-  block_rs: ReadSignal<Option<u64>>,
-  time_rs: ReadSignal<Option<std::time::SystemTime>>,
-) -> impl IntoView {
-  let block = block_rs;
+pub fn Footer(cx: Scope) -> impl IntoView {
+  let StreamContext {
+    block,
+    // TODO (@sectore) Remove it - just for testing serialization/deserialization LiveEvents (see #100)
+    time,
+    ..
+  } = use_context::<StreamContext>(cx).expect("Failed to get StreamContext");
 
-  // TODO (@sectore) Remove it - just for testing serialization/deserialization LiveEvents (see #100)
-  let time = time_rs;
   let current = move || match time.get() {
     None => String::from("--"),
     Some(v) => match v.duration_since(std::time::SystemTime::UNIX_EPOCH) {

--- a/src/app/components/livegrid.rs
+++ b/src/app/components/livegrid.rs
@@ -49,7 +49,7 @@ pub fn LiveGrid(
           each=counters
           key=|counter| counter.0
           view=move |cx, (_, (inscription_id, _)): (usize, (ReadSignal<String>, WriteSignal<String>))| {
-              view! { cx, <InscriptionItem id=inscription_id() /> }
+              view! { cx, <InscriptionItem id=inscription_id()/> }
           }
         />
       </ul>
@@ -64,7 +64,7 @@ pub fn InscriptionItem(cx: Scope, id: String) -> impl IntoView {
   view! { cx,
     <li class="relative">
       <A href=detail_url>
-        <Preview class id />
+        <Preview class id/>
       </A>
     </li>
   }

--- a/src/app/components/livegrid.rs
+++ b/src/app/components/livegrid.rs
@@ -1,25 +1,21 @@
 use leptos::*;
+use leptos_router::*;
 
-// const MANY_COUNTERS: usize = 4;
 #[allow(dead_code)]
 type CounterHolder = Vec<(usize, (ReadSignal<String>, WriteSignal<String>))>;
 
-// #[derive(Copy, Clone)]
-// struct CounterUpdater {
-//     set_counters: WriteSignal<CounterHolder>,
-// }
 #[allow(clippy::used_underscore_binding)]
 #[component]
 pub fn LiveGrid(
   cx: Scope,
-  initial_items: Vec<String>,
-  multiplayer_value: ReadSignal<Option<String>>,
+  initial_inscriptions: Vec<String>,
+  inscription_info: ReadSignal<Option<String>>,
 ) -> impl IntoView {
   let (next_counter_id, set_next_counter_id) = create_signal(cx, 0);
   let (counters, set_counters) = create_signal::<CounterHolder>(cx, vec![]);
   //provide_context(cx, CounterUpdater { set_counters });
 
-  for item in initial_items {
+  for item in initial_inscriptions {
     let id = next_counter_id();
     let sig = create_signal(cx, item);
     set_counters.update(move |counters| counters.push((id, sig)));
@@ -27,7 +23,7 @@ pub fn LiveGrid(
   }
 
   create_effect(cx, move |_| {
-    let s = multiplayer_value();
+    let s = inscription_info();
     //log!("effect: multiplayer_value = {:?}", s);
     if s.is_none() || s == Some("".to_string()) {
       return;
@@ -85,11 +81,11 @@ pub fn InscriptionItem(
   set_value: WriteSignal<String>,
 ) -> impl IntoView {
   let _ = set_value;
-  let _ = id;
+  let detail_url = move || format!("/inscription/{}", id);
   let preview_url = move || format!("/preview/{}", value.get());
   view! { cx,
     <li class="relative">
-      <a href=preview_url target=preview_url title="Click to view the unconfirmed inscription.">
+      <A href=detail_url>
         <div class="ring-2 ring-red-500 aspect-w-10 aspect-h-10 group block w-full overflow-hidden rounded-lg bg-gray-100">
           <iframe
             src=preview_url
@@ -98,11 +94,8 @@ pub fn InscriptionItem(
             loading="lazy"
             class="pointer-events-none object-cover"
           ></iframe>
-          <button type="button" class="absolute inset-0 focus:outline-none">
-            <span class="sr-only">"View details for ordinal"</span>
-          </button>
         </div>
-      </a>
+      </A>
     </li>
   }
 }

--- a/src/app/components/livegrid.rs
+++ b/src/app/components/livegrid.rs
@@ -9,7 +9,7 @@ type CounterHolder = Vec<(usize, (ReadSignal<String>, WriteSignal<String>))>;
 pub fn LiveGrid(
   cx: Scope,
   initial_inscriptions: Vec<String>,
-  inscription_info: ReadSignal<Option<String>>,
+  inscription: ReadSignal<Option<String>>,
 ) -> impl IntoView {
   let (next_counter_id, set_next_counter_id) = create_signal(cx, 0);
   let (counters, set_counters) = create_signal::<CounterHolder>(cx, vec![]);
@@ -23,7 +23,7 @@ pub fn LiveGrid(
   }
 
   create_effect(cx, move |_| {
-    let s = inscription_info();
+    let s = inscription();
     //log!("effect: multiplayer_value = {:?}", s);
     if s.is_none() || s == Some("".to_string()) {
       return;
@@ -48,8 +48,8 @@ pub fn LiveGrid(
         <For
           each=counters
           key=|counter| counter.0
-          view=move |cx, (id, (value, set_value)): (usize, (ReadSignal<String>, WriteSignal<String>))| {
-              view! { cx, <InscriptionItem id value set_value/> }
+          view=move |cx, (id, (value, _)): (usize, (ReadSignal<String>, WriteSignal<String>))| {
+              view! { cx, <InscriptionItem id value/> }
           }
         />
       </ul>
@@ -58,31 +58,9 @@ pub fn LiveGrid(
 }
 
 #[component]
-pub fn LiveItem(
-  cx: Scope,
-  id: usize,
-  value: ReadSignal<String>,
-  set_value: WriteSignal<String>,
-) -> impl IntoView {
-  //let CounterUpdater { set_counters } = use_context(cx).unwrap();
-  //let input = move |_ev| set_value("hello".to_owned());
-
-  //let default_value = move || value.get().to_owned() + " - " + id.to_string().as_ref();
-  let _ = set_value;
-  on_cleanup(cx, || log::debug!("deleted a row"));
-
-  view! { cx, <li>{id} ": " {value}</li> }
-}
-#[component]
-pub fn InscriptionItem(
-  cx: Scope,
-  id: usize,
-  value: ReadSignal<String>,
-  set_value: WriteSignal<String>,
-) -> impl IntoView {
-  let _ = set_value;
+pub fn InscriptionItem(cx: Scope, id: usize, value: ReadSignal<String>) -> impl IntoView {
   let detail_url = move || format!("/inscription/{}", id);
-  let preview_url = move || format!("/preview/{}", value.get());
+  let preview_url = move || format!("/preview/{}", value());
   view! { cx,
     <li class="relative">
       <A href=detail_url>

--- a/src/app/components/livegrid.rs
+++ b/src/app/components/livegrid.rs
@@ -60,7 +60,7 @@ pub fn LiveGrid(
 #[component]
 pub fn InscriptionItem(cx: Scope, id: String) -> impl IntoView {
   let detail_url = format!("/inscription/{}", &id);
-  let class = "aspect-w-10 aspect-h-10".to_string();
+  let class = "ring-2 ring-red-500 rounded-lg aspect-w-10 aspect-h-10".to_string();
   view! { cx,
     <li class="relative">
       <A href=detail_url>

--- a/src/app/components/livegrid.rs
+++ b/src/app/components/livegrid.rs
@@ -1,3 +1,4 @@
+use crate::app::components::preview::*;
 use leptos::*;
 use leptos_router::*;
 
@@ -9,7 +10,7 @@ type CounterHolder = Vec<(usize, (ReadSignal<String>, WriteSignal<String>))>;
 pub fn LiveGrid(
   cx: Scope,
   initial_inscriptions: Vec<String>,
-  inscription: ReadSignal<Option<String>>,
+  inscription_id: ReadSignal<Option<String>>,
 ) -> impl IntoView {
   let (next_counter_id, set_next_counter_id) = create_signal(cx, 0);
   let (counters, set_counters) = create_signal::<CounterHolder>(cx, vec![]);
@@ -23,8 +24,7 @@ pub fn LiveGrid(
   }
 
   create_effect(cx, move |_| {
-    let s = inscription();
-    //log!("effect: multiplayer_value = {:?}", s);
+    let s = inscription_id();
     if s.is_none() || s == Some("".to_string()) {
       return;
     }
@@ -37,7 +37,7 @@ pub fn LiveGrid(
   });
 
   view! { cx,
-    <section class="mt-8 pb-16" aria-labelledby="gallery-heading">
+    <section class="pt-8 pb-8" aria-labelledby="gallery-heading">
       <h2 id="gallery-heading" class="sr-only">
         "Recently viewed"
       </h2>
@@ -48,8 +48,8 @@ pub fn LiveGrid(
         <For
           each=counters
           key=|counter| counter.0
-          view=move |cx, (id, (value, _)): (usize, (ReadSignal<String>, WriteSignal<String>))| {
-              view! { cx, <InscriptionItem id value/> }
+          view=move |cx, (_, (inscription_id, _)): (usize, (ReadSignal<String>, WriteSignal<String>))| {
+              view! { cx, <InscriptionItem id=inscription_id() /> }
           }
         />
       </ul>
@@ -58,21 +58,13 @@ pub fn LiveGrid(
 }
 
 #[component]
-pub fn InscriptionItem(cx: Scope, id: usize, value: ReadSignal<String>) -> impl IntoView {
-  let detail_url = move || format!("/inscription/{}", id);
-  let preview_url = move || format!("/preview/{}", value());
+pub fn InscriptionItem(cx: Scope, id: String) -> impl IntoView {
+  let detail_url = format!("/inscription/{}", &id);
+  let class = "aspect-w-10 aspect-h-10".to_string();
   view! { cx,
     <li class="relative">
       <A href=detail_url>
-        <div class="ring-2 ring-red-500 aspect-w-10 aspect-h-10 group block w-full overflow-hidden rounded-lg bg-gray-100">
-          <iframe
-            src=preview_url
-            sandbox="allow-scripts"
-            scrolling="no"
-            loading="lazy"
-            class="pointer-events-none object-cover"
-          ></iframe>
-        </div>
+        <Preview class id />
       </A>
     </li>
   }

--- a/src/app/components/livegrid.rs
+++ b/src/app/components/livegrid.rs
@@ -60,7 +60,7 @@ pub fn LiveGrid(
 #[component]
 pub fn InscriptionItem(cx: Scope, id: String) -> impl IntoView {
   let detail_url = format!("/inscription/{}", &id);
-  let class = "ring-2 ring-red-500 rounded-lg aspect-w-10 aspect-h-10".to_string();
+  let class = "ring-2 ring-red-500 rounded-lg aspect-w-10 aspect-h-10";
   view! { cx,
     <li class="relative">
       <A href=detail_url>

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -1,6 +1,9 @@
 mod layout;
 mod livegrid;
+pub mod preview;
 mod theme_toggle;
+
 pub use layout::*;
 pub use livegrid::*;
+pub use preview::*;
 pub use theme_toggle::*;

--- a/src/app/components/preview.rs
+++ b/src/app/components/preview.rs
@@ -9,14 +9,14 @@ pub fn Preview(cx: Scope, id: String, #[prop(optional)] class: String) -> impl I
   );
 
   view! { cx,
-        <div class=clazz>
-          <iframe
-            src=preview_url
-            sandbox="allow-scripts"
-            scrolling="no"
-            loading="lazy"
-            class="pointer-events-none object-cover"
-          ></iframe>
-        </div>
+    <div class=clazz>
+      <iframe
+        src=preview_url
+        sandbox="allow-scripts"
+        scrolling="no"
+        loading="lazy"
+        class="pointer-events-none object-cover"
+      ></iframe>
+    </div>
   }
 }

--- a/src/app/components/preview.rs
+++ b/src/app/components/preview.rs
@@ -1,12 +1,11 @@
 use leptos::*;
 
 #[component]
-pub fn Preview(cx: Scope, id: String, #[prop(optional)] class: String) -> impl IntoView {
+pub fn Preview(cx: Scope, id: String, #[prop(optional)] class: &'static str) -> impl IntoView {
   let preview_url = move || format!("/preview/{}", id);
-  let clazz = format!("block w-full overflow-hidden bg-gray-100 {}", class);
 
   view! { cx,
-    <div class=clazz>
+    <div class=format!("block w-full overflow-hidden bg-gray-100 {class}")>
       <iframe
         src=preview_url
         sandbox="allow-scripts"

--- a/src/app/components/preview.rs
+++ b/src/app/components/preview.rs
@@ -3,10 +3,7 @@ use leptos::*;
 #[component]
 pub fn Preview(cx: Scope, id: String, #[prop(optional)] class: String) -> impl IntoView {
   let preview_url = move || format!("/preview/{}", id);
-  let clazz = format!(
-    "ring-2 ring-red-500 group block w-full overflow-hidden rounded-lg bg-gray-100 {}",
-    class
-  );
+  let clazz = format!("block w-full overflow-hidden bg-gray-100 {}", class);
 
   view! { cx,
     <div class=clazz>

--- a/src/app/components/preview.rs
+++ b/src/app/components/preview.rs
@@ -1,8 +1,12 @@
 use leptos::*;
 
 #[component]
-pub fn Preview(cx: Scope, id: String, #[prop(optional)] class: &'static str) -> impl IntoView {
-  let preview_url = move || format!("/preview/{}", id);
+pub fn Preview(
+  cx: Scope,
+  hash: Signal<String>,
+  #[prop(optional)] class: &'static str,
+) -> impl IntoView {
+  let preview_url = move || format!("/preview/{}", hash());
 
   view! { cx,
     <div class=format!("block w-full overflow-hidden bg-gray-100 {class}")>

--- a/src/app/components/preview.rs
+++ b/src/app/components/preview.rs
@@ -1,0 +1,22 @@
+use leptos::*;
+
+#[component]
+pub fn Preview(cx: Scope, id: String, #[prop(optional)] class: String) -> impl IntoView {
+  let preview_url = move || format!("/preview/{}", id);
+  let clazz = format!(
+    "ring-2 ring-red-500 group block w-full overflow-hidden rounded-lg bg-gray-100 {}",
+    class
+  );
+
+  view! { cx,
+        <div class=clazz>
+          <iframe
+            src=preview_url
+            sandbox="allow-scripts"
+            scrolling="no"
+            loading="lazy"
+            class="pointer-events-none object-cover"
+          ></iframe>
+        </div>
+  }
+}

--- a/src/app/components/theme_toggle.rs
+++ b/src/app/components/theme_toggle.rs
@@ -14,7 +14,7 @@ pub fn ThemeToggle(cx: Scope) -> impl IntoView {
       <input type="hidden" name="is_dark" value=move || (!is_dark()).to_string()/>
       <button
         type="submit"
-        class="cursor-pointer rounded-full bg-gray-500 p-2 text-gray-100 hover:text-yellow-400 ml-2"
+        class="cursor-pointer rounded-full ease hover:bg-white/20 bg-transparent p-2 text-gray-100 hover:text-yellow-400 ml-2"
         inner_html=move || {
             if is_dark() {
                 r#"<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"></path></svg>"#

--- a/src/app/functions/inscription.rs
+++ b/src/app/functions/inscription.rs
@@ -1,0 +1,18 @@
+use cfg_if::cfg_if;
+
+cfg_if! {
+  if #[cfg(feature = "ssr")] {
+
+    use leptos::*;
+
+    #[server(GetLastInscription, "/api")]
+    pub async fn get_last_inscription() -> Result<String, ServerFnError> {
+      Ok("".to_string())
+    }
+
+    #[server(GetInscriptionDetails, "/api")]
+    pub async fn get_inscription_details(id: String) -> Result<i32, ServerFnError> {
+        Ok(42)
+    }
+  }
+}

--- a/src/app/functions/inscription.rs
+++ b/src/app/functions/inscription.rs
@@ -5,11 +5,6 @@ cfg_if! {
 
     use leptos::*;
 
-    #[server(GetLastInscription, "/api")]
-    pub async fn get_last_inscription() -> Result<String, ServerFnError> {
-      Ok("".to_string())
-    }
-
     #[server(GetInscriptionDetails, "/api")]
     pub async fn get_inscription_details(id: String) -> Result<i32, ServerFnError> {
         Ok(42)

--- a/src/app/functions/mod.rs
+++ b/src/app/functions/mod.rs
@@ -1,0 +1,19 @@
+pub mod inscription;
+pub mod theme;
+
+pub use inscription::*;
+pub use theme::*;
+
+use cfg_if::cfg_if;
+
+cfg_if! {
+  if #[cfg(feature = "ssr")] {
+
+    use leptos::ServerFn;
+
+    pub fn register_server_functions() {
+      _ = inscription::GetLastInscription::register();
+      _ = inscription::GetInscriptionDetails::register();
+      _ = theme::SetDarkTheme::register();
+    }
+}}

--- a/src/app/functions/mod.rs
+++ b/src/app/functions/mod.rs
@@ -12,7 +12,6 @@ cfg_if! {
     use leptos::ServerFn;
 
     pub fn register_server_functions() {
-      _ = inscription::GetLastInscription::register();
       _ = inscription::GetInscriptionDetails::register();
       _ = theme::SetDarkTheme::register();
     }

--- a/src/app/functions/theme.rs
+++ b/src/app/functions/theme.rs
@@ -1,0 +1,23 @@
+use leptos::*;
+
+#[server(SetDarkTheme, "/api")]
+pub async fn set_dark_theme(
+  #[allow(unused_variables)] cx: Scope,
+  is_dark: bool,
+) -> Result<bool, ServerFnError> {
+  use axum::http::header::{HeaderMap, HeaderValue, SET_COOKIE};
+  use leptos_axum::{ResponseOptions, ResponseParts};
+
+  let response =
+    use_context::<ResponseOptions>(cx).expect("to have leptos_axum::ResponseOptions provided");
+  let mut response_parts = ResponseParts::default();
+  let mut headers = HeaderMap::new();
+  headers.insert(
+    SET_COOKIE,
+    HeaderValue::from_str(&format!("darkmode={is_dark}; Path=/")).expect("to create header value"),
+  );
+  response_parts.headers = headers;
+
+  response.overwrite(response_parts);
+  Ok(is_dark)
+}

--- a/src/app/providers/mod.rs
+++ b/src/app/providers/mod.rs
@@ -1,3 +1,5 @@
+pub mod stream;
 pub mod theme;
 
+pub use stream::*;
 pub use theme::*;

--- a/src/app/providers/stream.rs
+++ b/src/app/providers/stream.rs
@@ -1,0 +1,104 @@
+#![allow(dead_code)]
+use std::*;
+
+use leptos::*;
+
+use std::time::SystemTime;
+
+#[derive(Clone)]
+pub(crate) struct StreamContext {
+  pub inscription: ReadSignal<Option<String>>,
+  pub info: ReadSignal<Option<String>>,
+  pub block: ReadSignal<Option<u64>>,
+  pub time: ReadSignal<Option<SystemTime>>,
+}
+
+pub fn provide_api_context(cx: Scope) {
+  if use_context::<StreamContext>(cx).is_none() {
+    #[cfg(not(feature = "ssr"))]
+    let context = {
+      use futures::StreamExt;
+
+      let mut source = gloo_net::eventsource::futures::EventSource::new("/api/events")
+        .expect("couldn't connect to SSE stream");
+
+      // Note:
+      // All data of subscriptions are stringified JSON (similar to `JSON.stringify` in JS) - see implementation in `main.rs -> sse_handler`
+      // And needs to be deserialized `serde_json::from_str` (similar to `JSON.parse` in JS)
+
+      let inscription = create_signal_from_stream(
+        cx,
+        source.subscribe("inscription").unwrap().map(|value| {
+          let s = value
+            .expect("no message event")
+            .1
+            .data()
+            .as_string()
+            .expect("expected string value");
+
+          serde_json::from_str::<String>(s.as_str()).expect("expected String value")
+        }),
+      );
+
+      let info = create_signal_from_stream(
+        cx,
+        source.subscribe("info").unwrap().map(|value| {
+          let s = value
+            .expect("no message event")
+            .1
+            .data()
+            .as_string()
+            .expect("expected string value");
+
+          serde_json::from_str::<String>(s.as_str()).expect("expected String value")
+        }),
+      );
+
+      let block = create_signal_from_stream(
+        cx,
+        source.subscribe("block").unwrap().map(|value| {
+          let s = value
+            .expect("no message event")
+            .1
+            .data()
+            .as_string()
+            .expect("expected string value");
+          serde_json::from_str::<u64>(s.as_str()).expect("expected u64 value")
+        }),
+      );
+
+      // TODO (@sectore) Remove it - just for testing serialization/deserialization LiveEvents (see #100)
+      let time = create_signal_from_stream(
+        cx,
+        source.subscribe("time").unwrap().map(|value| {
+          let s = value
+            .expect("no message event")
+            .1
+            .data()
+            .as_string()
+            .expect("expected string value");
+          serde_json::from_str::<SystemTime>(s.as_str()).expect("expected SystemTime value")
+        }),
+      );
+
+      on_cleanup(cx, move || source.close());
+
+      StreamContext {
+        inscription,
+        info,
+        block,
+        time,
+      }
+    };
+
+    #[cfg(feature = "ssr")]
+    let context = StreamContext {
+      inscription: create_signal(cx, None::<String>).0,
+      info: create_signal(cx, None::<String>).0,
+      block: create_signal(cx, None::<u64>).0,
+      time: create_signal(cx, None::<SystemTime>).0,
+    };
+
+    provide_context(cx, context);
+  }
+}

--- a/src/app/providers/stream.rs
+++ b/src/app/providers/stream.rs
@@ -13,7 +13,7 @@ pub(crate) struct StreamContext {
   pub time: ReadSignal<Option<SystemTime>>,
 }
 
-pub fn provide_api_context(cx: Scope) {
+pub fn provide_stream_context(cx: Scope) {
   if use_context::<StreamContext>(cx).is_none() {
     #[cfg(not(feature = "ssr"))]
     let context = {

--- a/src/app/providers/theme.rs
+++ b/src/app/providers/theme.rs
@@ -1,8 +1,7 @@
-#![allow(dead_code)]
+use leptos::*;
 use std::*;
 
-use crate::app::SetDarkTheme;
-use leptos::*;
+use crate::app::functions::theme::SetDarkTheme;
 
 #[derive(Clone)]
 pub(crate) struct ThemeContext {

--- a/src/app/providers/theme.rs
+++ b/src/app/providers/theme.rs
@@ -3,12 +3,14 @@ use std::*;
 
 use crate::app::functions::theme::SetDarkTheme;
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct ThemeContext {
   pub set_dark_action: Action<SetDarkTheme, Result<bool, ServerFnError>>,
   pub is_dark: Signal<bool>,
 }
 
+#[allow(dead_code)]
 #[cfg(not(feature = "ssr"))]
 fn initial_theme(_cx: Scope) -> bool {
   use wasm_bindgen::JsCast;
@@ -34,6 +36,7 @@ fn initial_theme(cx: Scope) -> bool {
     .unwrap_or(false)
 }
 
+#[allow(dead_code)]
 pub fn provide_theme_context(cx: Scope) {
   if use_context::<ThemeContext>(cx).is_none() {
     let initial = initial_theme(cx);

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -4,12 +4,11 @@ use leptos::*;
 
 #[component]
 pub fn Home(cx: Scope) -> impl IntoView {
-  let StreamContext { info, .. } =
-    use_context::<StreamContext>(cx).expect("Failed to get StreamContext");
+  let StreamContext {
+    info, inscription, ..
+  } = use_context::<StreamContext>(cx).expect("Failed to get StreamContext");
 
   let initial_inscriptions: Vec<_> = (0..6).map(|n| format!("punk_{}.webp", n)).collect();
-
-  let inscription_info = info;
 
   view! { cx,
     <div class="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
@@ -18,8 +17,8 @@ pub fn Home(cx: Scope) -> impl IntoView {
           "Live unconfirmed inscriptions"
         </h1>
       </div>
-      <div class="text-xs text-gray-900 dark:text-gray-100">{inscription_info}</div>
-      <LiveGrid initial_inscriptions inscription_info/>
+      <div class="text-xs text-gray-900 dark:text-gray-100">{info}</div>
+      <LiveGrid initial_inscriptions inscription/>
     </div>
   }
 }

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -11,14 +11,14 @@ pub fn Home(cx: Scope) -> impl IntoView {
   let initial_inscriptions: Vec<_> = (0..6).map(|n| format!("punk_{}.webp", n)).collect();
 
   view! { cx,
-    <div class="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
+    <div class="content py-8">
       <div class="flex">
         <h1 class="flex-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
           "Live unconfirmed inscriptions"
         </h1>
       </div>
       <div class="text-xs text-gray-900 dark:text-gray-100">{info}</div>
-      <LiveGrid initial_inscriptions inscription/>
+      <LiveGrid initial_inscriptions inscription_id=inscription/>
     </div>
   }
 }

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -17,7 +17,7 @@ pub fn Home(cx: Scope) -> impl IntoView {
           "Live unconfirmed inscriptions"
         </h1>
       </div>
-      <div class="text-xs text-gray-900 leading-4 dark:text-gray-100 empty:after:content-['*'] empty:after:opacity-0">
+      <div class="text-xs text-gray-900 dark:text-gray-100 empty:after:content-['\u{200b}'] empty:after:inline-block">
         {info}
       </div>
       <LiveGrid initial_inscriptions inscription_id=inscription/>

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -1,0 +1,25 @@
+use crate::app::components::*;
+use crate::app::providers::*;
+use leptos::*;
+
+#[component]
+pub fn Home(cx: Scope) -> impl IntoView {
+  let StreamContext { info, .. } =
+    use_context::<StreamContext>(cx).expect("Failed to get StreamContext");
+
+  let initial_inscriptions: Vec<_> = (0..6).map(|n| format!("punk_{}.webp", n)).collect();
+
+  let inscription_info = info;
+
+  view! { cx,
+    <div class="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
+      <div class="flex">
+        <h1 class="flex-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
+          "Live unconfirmed inscriptions"
+        </h1>
+      </div>
+      <div class="text-xs text-gray-900 dark:text-gray-100">{inscription_info}</div>
+      <LiveGrid initial_inscriptions inscription_info/>
+    </div>
+  }
+}

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -17,9 +17,9 @@ pub fn Home(cx: Scope) -> impl IntoView {
           "Live unconfirmed inscriptions"
         </h1>
       </div>
-      // Keep heihgt for empty content - `&#8203;` doesn't work in Leptos - that's why adding a * and make it transparent
-      // Question in Leptos Discord https://discord.com/channels/1031524867910148188/1102915498817097821/1102915498817097821
-      <div class="text-xs text-gray-900 leading-4 dark:text-gray-100 empty:after:content-['*'] empty:after:opacity-0">{info}</div>
+      <div class="text-xs text-gray-900 leading-4 dark:text-gray-100 empty:after:content-['*'] empty:after:opacity-0">
+        {info}
+      </div>
       <LiveGrid initial_inscriptions inscription_id=inscription/>
     </div>
   }

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -17,7 +17,9 @@ pub fn Home(cx: Scope) -> impl IntoView {
           "Live unconfirmed inscriptions"
         </h1>
       </div>
-      <div class="text-xs text-gray-900 dark:text-gray-100">{info}</div>
+      // Keep heihgt for empty content - `&#8203;` doesn't work in Leptos - that's why adding a * and make it transparent
+      // Question in Leptos Discord https://discord.com/channels/1031524867910148188/1102915498817097821/1102915498817097821
+      <div class="text-xs text-gray-900 leading-4 dark:text-gray-100 empty:after:content-['*'] empty:after:opacity-0">{info}</div>
       <LiveGrid initial_inscriptions inscription_id=inscription/>
     </div>
   }

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -30,7 +30,7 @@ pub fn Label(cx: Scope, children: Children) -> impl IntoView {
 pub fn Inscription(cx: Scope) -> impl IntoView {
   let params = use_params_map(cx);
   let id = move || params().get("id").cloned().unwrap_or_default();
-  let preview_url = move || format!("/preview/{}", &id());
+  let (fullscreen, set_fullscreen) = create_signal(cx, false);
 
   view! { cx,
     <div class="content">
@@ -42,35 +42,34 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
               }
               false => {
                   view! { cx,
-                    <div class="px-20 md:px-40 lg:px-60 my-10 flex items-center justify-center">
-                      <div class="relative w-full h-full">
+                    <div class="relative px-20 md:px-40 lg:px-60 my-10 flex items-center justify-center">
+                      <button
+                        class="group relative w-full h-full"
+                        on:click=move |_| set_fullscreen.set(true)
+                      >
                         <Preview
-                          class="w-full h-full aspect-w-4 aspect-h-4 ring-4 sm:ring-8".to_owned()
+                          class="ring-4 sm:ring-8 ring-red-500 rounded-lg aspect-w-4 aspect-h-4 group-hover:brightness-100"
+                              .to_owned()
                           id=id()
                         />
-                        <a
-                          href=preview_url
-                          target=preview_url
-                          title="Click to view the unconfirmed inscription."
-                        >
-                          <div class="absolute right-1 bottom-1 ease bg-white/70 hover:bg-white/90 text-gray-700 hover:text-gray-900 dark:text-gray-200 hover:dark:text-gray-50 dark:bg-slate-900/70 dark:hover:bg-slate-900/90 w-6 h-6 sm:w-10 sm:h-10 flex justify-center items-center p-1 sm:p-2 rounded-lg">
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              strokeWidth=1.5
-                              stroke="currentColor"
-                              class="w-6 h-6"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                              ></path>
-                            </svg>
-                          </div>
-                        </a>
-                      </div>
+                        <div class="absolute right-2 top-2 sm:right-5 sm:top-5 shadow-md ease
+                        bg-white opacity-80 group-hover:opacity-100 text-gray-900 w-6 h-6 sm:w-10 sm:h-10 flex justify-center items-center p-1 sm:p-2 rounded-full">
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            strokeWidth=1.5
+                            stroke="currentColor"
+                            class="w-6 h-6"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                            ></path>
+                          </svg>
+                        </div>
+                      </button>
                     </div>
                     <Container>
                       <Title>"id"</Title>
@@ -155,6 +154,29 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
         </svg>
         "Back"
       </A>
+      <Show
+        when=move || fullscreen()
+        fallback=|cx| {
+            view! { cx, <></> }
+                .into_view(cx)
+        }
+      >
+        <button class="group absolute inset-0" on:click=move |_| set_fullscreen.set(false)>
+          <Preview class="absolute inset-0 aspect-w-4 aspect-h-4".to_owned() id=id()/>
+          <div class="absolute right-4 top-4 p-2 ease bg-white opacity-80 group-hover:opacity-100 shadow-md rounded-full text-gray-600">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="w-6 h-6"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+          </div>
+        </button>
+      </Show>
     </div>
   }
 }

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -84,51 +84,47 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
                         view! { cx,
                           <Container>
                             <Title>"address"</Title>
-                            <Label>"bc1pyqz4gyra5cssfgawk6dunh4s9car9zrzpkw2l0sz4g9ym0cdxzescnf4u2"</Label>
+                            <Label>"bc1pz4kvfpurqc2hwgrq0nwtfve2lfxvdpfcdpzc6ujchyr3ztj6gd9sfr6ayf"</Label>
                           </Container>
                           <Container>
                             <Title>"output value"</Title>
-                            <Label>"546"</Label>
+                            <Label>"10000"</Label>
                           </Container>
                           <Container>
                             <Title>"sat"</Title>
-                            <Label>"1862722370424422"</Label>
+                            <Label>"1252201400444387"</Label>
                           </Container>
                           <Container>
                             <Title>"content length"</Title>
-                            <Label>"53 bytes"</Label>
+                            <Label>"793 bytes"</Label>
                           </Container>
                           <Container>
                             <Title>"content type"</Title>
-                            <Label>"text/plain;charset=utf-8"</Label>
+                            <Label>"image/png"</Label>
                           </Container>
                           <Container>
                             <Title>"time stamp"</Title>
-                            <Label>"2023-04-26 13:54:04 UTC"</Label>
-                          </Container>
-                          <Container>
-                            <Title>"time stamp"</Title>
-                            <Label>"2023-04-26 13:54:04 UTC"</Label>
+                            <Label>"2022-12-14 20:32:00 UTC"</Label>
                           </Container>
                           <Container>
                             <Title>"genesis height"</Title>
-                            <Label>"787095"</Label>
+                            <Label>"767430"</Label>
                           </Container>
                           <Container>
                             <Title>"genesis fee"</Title>
-                            <Label>"2448"</Label>
+                            <Label>"322"</Label>
                           </Container>
                           <Container>
                             <Title>"genesis transaction"</Title>
-                            <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c"</Label>
+                            <Label>"6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799"</Label>
                           </Container>
                           <Container>
                             <Title>"location"</Title>
-                            <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0:0"</Label>
+                            <Label>"bc4c30829a9564c0d58e6287195622b53ced54a25711d1b86be7cd3a70ef61ed:0:0"</Label>
                           </Container>
                           <Container>
                             <Title>"output"</Title>
-                            <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0"</Label>
+                            <Label>"bc4c30829a9564c0d58e6287195622b53ced54a25711d1b86be7cd3a70ef61ed:0"</Label>
                           </Container>
                           <Container>
                             <Title>"offset"</Title>

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -6,21 +6,23 @@ use leptos_router::*;
 #[component]
 pub fn Container(cx: Scope, children: Children) -> impl IntoView {
   view! { cx,
-    <div class="pt-2 pb-2 lg:pt-3 lg:pb-4 px-4 bg-white even:bg-gray-100 dark:bg-slate-800 dark:even:bg-slate-900 ">{children(cx)}</div>
+    <div class="pt-2 pb-2 lg:pt-3 lg:pb-4 px-4 bg-white even:bg-gray-100 dark:bg-slate-800 dark:even:bg-slate-900 ">
+      {children(cx)}
+    </div>
   }
 }
 
 #[component]
 pub fn Title(cx: Scope, children: Children) -> impl IntoView {
-  view! { cx,
-    <h3 class="text-xs lg:text-md text-gray-400 dark:text-gray-400">{children(cx)}</h3>
-  }
+  view! { cx, <h3 class="text-xs lg:text-md text-gray-400 dark:text-gray-400">{children(cx)}</h3> }
 }
 
 #[component]
 pub fn Label(cx: Scope, children: Children) -> impl IntoView {
   view! { cx,
-    <h2 class="text-xs sm:text-base lg:text-2xl text-gray-800 dark:text-gray-200 text-ellipsis overflow-hidden">{children(cx)}</h2>
+    <h2 class="text-xs sm:text-base lg:text-2xl text-gray-800 dark:text-gray-200 text-ellipsis overflow-hidden">
+      {children(cx)}
+    </h2>
   }
 }
 
@@ -33,87 +35,126 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
   view! { cx,
     <div class="content">
       {move || {
-        match &id().is_empty() {
-          true => view!{cx, <h1 class="text-4xl text-center">"Invalid inscription id"</h1>}.into_view(cx),
-          false => view!{cx,
-            <div class="px-20 md:px-40 lg:px-60 my-10 flex items-center justify-center">
-              <div class="relative w-full h-full">
-                <Preview class="w-full h-full aspect-w-4 aspect-h-4 ring-4 sm:ring-8".to_owned() id=id() />
-                  <a href=preview_url target=preview_url title="Click to view the unconfirmed inscription.">
-                    <div class="absolute right-1 bottom-1 ease bg-white/70 hover:bg-white/90 text-gray-700 hover:text-gray-900 dark:text-gray-200 hover:dark:text-gray-50 dark:bg-slate-900/70 dark:hover:bg-slate-900/90 w-6 h-6 sm:w-10 sm:h-10 flex justify-center items-center p-1 sm:p-2 rounded-lg">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" class="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-                      </svg>
+          match &id().is_empty() {
+              true => {
+                  view! { cx, <h1 class="text-4xl text-center">"Invalid inscription id"</h1> }
+                      .into_view(cx)
+              }
+              false => {
+                  view! { cx,
+                    <div class="px-20 md:px-40 lg:px-60 my-10 flex items-center justify-center">
+                      <div class="relative w-full h-full">
+                        <Preview
+                          class="w-full h-full aspect-w-4 aspect-h-4 ring-4 sm:ring-8".to_owned()
+                          id=id()
+                        />
+                        <a
+                          href=preview_url
+                          target=preview_url
+                          title="Click to view the unconfirmed inscription."
+                        >
+                          <div class="absolute right-1 bottom-1 ease bg-white/70 hover:bg-white/90 text-gray-700 hover:text-gray-900 dark:text-gray-200 hover:dark:text-gray-50 dark:bg-slate-900/70 dark:hover:bg-slate-900/90 w-6 h-6 sm:w-10 sm:h-10 flex justify-center items-center p-1 sm:p-2 rounded-lg">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              strokeWidth=1.5
+                              stroke="currentColor"
+                              class="w-6 h-6"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                              ></path>
+                            </svg>
+                          </div>
+                        </a>
+                      </div>
                     </div>
-                  </a>
-              </div>
-            </div>
-            <Container>
-              <Title>"id"</Title>
-              <Label>{&id()}</Label>
-            </Container>
-            <Container>
-              <Title>"address"</Title>
-              <Label>"bc1pyqz4gyra5cssfgawk6dunh4s9car9zrzpkw2l0sz4g9ym0cdxzescnf4u2"</Label>
-            </Container>
-            <Container>
-              <Title>"output value"</Title>
-              <Label>"546"</Label>
-            </Container>
-            <Container>
-              <Title>"sat"</Title>
-              <Label>"1862722370424422"</Label>
-            </Container>
-            <Container>
-              <Title>"content length"</Title>
-              <Label>"53 bytes"</Label>
-            </Container>
-            <Container>
-              <Title>"content type"</Title>
-              <Label>"text/plain;charset=utf-8"</Label>
-            </Container>
-            <Container>
-              <Title>"time stamp"</Title>
-              <Label>"2023-04-26 13:54:04 UTC"</Label>
-            </Container>
-            <Container>
-              <Title>"time stamp"</Title>
-              <Label>"2023-04-26 13:54:04 UTC"</Label>
-            </Container>
-            <Container>
-              <Title>"genesis height"</Title>
-              <Label>"787095"</Label>
-            </Container>
-            <Container>
-              <Title>"genesis fee"</Title>
-              <Label>"2448"</Label>
-            </Container>
-            <Container>
-              <Title>"genesis transaction"</Title>
-              <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c"</Label>
-            </Container>
-            <Container>
-              <Title>"location"</Title>
-              <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0:0"</Label>
-            </Container>
-            <Container>
-              <Title>"output"</Title>
-              <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0"</Label>
-            </Container>
-            <Container>
-              <Title>"offset"</Title>
-              <Label>"0"</Label>
-            </Container>
-          }.into_view(cx),
-        }
-      }
-    }
-    <A href="/" class="flex justify-center items-center ease text-gray-400 hover:text-gray-500 dark:text-gray-300 dark:hover:text-gray-200 p-4 my-5 text-md lg:text-xl">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 mr-1">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 9l-3 3m0 0l3 3m-3-3h7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-    "Back"
-    </A>
+                    <Container>
+                      <Title>"id"</Title>
+                      <Label>{&id()}</Label>
+                    </Container>
+                    <Container>
+                      <Title>"address"</Title>
+                      <Label>"bc1pyqz4gyra5cssfgawk6dunh4s9car9zrzpkw2l0sz4g9ym0cdxzescnf4u2"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"output value"</Title>
+                      <Label>"546"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"sat"</Title>
+                      <Label>"1862722370424422"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"content length"</Title>
+                      <Label>"53 bytes"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"content type"</Title>
+                      <Label>"text/plain;charset=utf-8"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"time stamp"</Title>
+                      <Label>"2023-04-26 13:54:04 UTC"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"time stamp"</Title>
+                      <Label>"2023-04-26 13:54:04 UTC"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"genesis height"</Title>
+                      <Label>"787095"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"genesis fee"</Title>
+                      <Label>"2448"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"genesis transaction"</Title>
+                      <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"location"</Title>
+                      <Label>
+                        "a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0:0"
+                      </Label>
+                    </Container>
+                    <Container>
+                      <Title>"output"</Title>
+                      <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0"</Label>
+                    </Container>
+                    <Container>
+                      <Title>"offset"</Title>
+                      <Label>"0"</Label>
+                    </Container>
+                  }
+                      .into_view(cx)
+              }
+          }
+      }}
+      <A
+        href="/"
+        class="flex justify-center items-center ease text-gray-400 hover:text-gray-500 dark:text-gray-300 dark:hover:text-gray-200 p-4 my-5 text-md lg:text-xl"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-6 h-6 mr-1"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M11.25 9l-3 3m0 0l3 3m-3-3h7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          ></path>
+        </svg>
+        "Back"
+      </A>
     </div>
   }
 }

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -49,7 +49,6 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
                       >
                         <Preview
                           class="ring-4 sm:ring-8 ring-red-500 rounded-lg aspect-w-4 aspect-h-4 group-hover:brightness-100"
-                              .to_owned()
                           id=id()
                         />
                         <div class="absolute right-2 top-2 sm:right-5 sm:top-5 shadow-md ease
@@ -162,7 +161,7 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
         }
       >
         <button class="group absolute w-full inset-0" on:click=move |_| set_fullscreen.set(false)>
-          <Preview class="absolute inset-0 aspect-w-4 aspect-h-4".to_owned() id=id()/>
+          <Preview class="absolute inset-0 aspect-w-4 aspect-h-4" id=id()/>
           <div class="absolute right-4 top-4 p-2 ease bg-white opacity-80 group-hover:opacity-100 shadow-md rounded-full text-gray-600">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -161,7 +161,7 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
                 .into_view(cx)
         }
       >
-        <button class="group absolute inset-0" on:click=move |_| set_fullscreen.set(false)>
+        <button class="group absolute w-full inset-0" on:click=move |_| set_fullscreen.set(false)>
           <Preview class="absolute inset-0 aspect-w-4 aspect-h-4".to_owned() id=id()/>
           <div class="absolute right-4 top-4 p-2 ease bg-white opacity-80 group-hover:opacity-100 shadow-md rounded-full text-gray-600">
             <svg

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -30,6 +30,7 @@ pub fn Label(cx: Scope, children: Children) -> impl IntoView {
 pub fn Inscription(cx: Scope) -> impl IntoView {
   let params = use_params_map(cx);
   let id = move || params().get("id").cloned().unwrap_or_default();
+  let hash = id.derive_signal(cx);
   let (fullscreen, set_fullscreen) = create_signal(cx, false);
 
   view! { cx,
@@ -49,7 +50,7 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
                       >
                         <Preview
                           class="ring-4 sm:ring-8 ring-red-500 rounded-lg aspect-w-4 aspect-h-4 group-hover:brightness-100"
-                          id=id()
+                          hash
                         />
                         <div class="absolute right-2 top-2 sm:right-5 sm:top-5 shadow-md ease
                         bg-white opacity-80 group-hover:opacity-100 text-gray-900 w-6 h-6 sm:w-10 sm:h-10 flex justify-center items-center p-1 sm:p-2 rounded-full">
@@ -161,7 +162,7 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
         }
       >
         <button class="group absolute w-full inset-0" on:click=move |_| set_fullscreen.set(false)>
-          <Preview class="absolute inset-0 aspect-w-4 aspect-h-4" id=id()/>
+          <Preview class="absolute inset-0 aspect-w-4 aspect-h-4" hash/>
           <div class="absolute right-4 top-4 p-2 ease bg-white opacity-80 group-hover:opacity-100 shadow-md rounded-full text-gray-600">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -1,0 +1,17 @@
+use leptos::*;
+use leptos_router::*;
+
+#[component]
+pub fn Inscription(cx: Scope) -> impl IntoView {
+  let params = use_params_map(cx);
+  let id = move || params().get("id").cloned();
+
+  view! { cx,
+    <div class="">
+      <h1>"Inscription" {id()}</h1>
+      <A href="/">
+        <strong>"Back to home"</strong>
+      </A>
+    </div>
+  }
+}

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -1,17 +1,119 @@
+use crate::app::components::preview::*;
+
 use leptos::*;
 use leptos_router::*;
 
 #[component]
+pub fn Container(cx: Scope, children: Children) -> impl IntoView {
+  view! { cx,
+    <div class="pt-2 pb-2 lg:pt-3 lg:pb-4 px-4 bg-white even:bg-gray-100 dark:bg-slate-800 dark:even:bg-slate-900 ">{children(cx)}</div>
+  }
+}
+
+#[component]
+pub fn Title(cx: Scope, children: Children) -> impl IntoView {
+  view! { cx,
+    <h3 class="text-xs lg:text-md text-gray-400 dark:text-gray-400">{children(cx)}</h3>
+  }
+}
+
+#[component]
+pub fn Label(cx: Scope, children: Children) -> impl IntoView {
+  view! { cx,
+    <h2 class="text-xs sm:text-base lg:text-2xl text-gray-800 dark:text-gray-200 text-ellipsis overflow-hidden">{children(cx)}</h2>
+  }
+}
+
+#[component]
 pub fn Inscription(cx: Scope) -> impl IntoView {
   let params = use_params_map(cx);
-  let id = move || params().get("id").cloned();
+  let id = move || params().get("id").cloned().unwrap_or_default();
+  let preview_url = move || format!("/preview/{}", &id());
 
   view! { cx,
-    <div class="">
-      <h1>"Inscription" {id()}</h1>
-      <A href="/">
-        <strong>"Back to home"</strong>
-      </A>
+    <div class="content">
+      {move || {
+        match &id().is_empty() {
+          true => view!{cx, <h1 class="text-4xl text-center">"Invalid inscription id"</h1>}.into_view(cx),
+          false => view!{cx,
+            <div class="px-20 md:px-40 lg:px-60 my-10 flex items-center justify-center">
+              <div class="relative w-full h-full">
+                <Preview class="w-full h-full aspect-w-4 aspect-h-4 ring-4 sm:ring-8".to_owned() id=id() />
+                  <a href=preview_url target=preview_url title="Click to view the unconfirmed inscription.">
+                    <div class="absolute right-1 bottom-1 ease bg-white/70 hover:bg-white/90 text-gray-700 hover:text-gray-900 dark:text-gray-200 hover:dark:text-gray-50 dark:bg-slate-900/70 dark:hover:bg-slate-900/90 w-6 h-6 sm:w-10 sm:h-10 flex justify-center items-center p-1 sm:p-2 rounded-lg">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" class="w-6 h-6">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+                      </svg>
+                    </div>
+                  </a>
+              </div>
+            </div>
+            <Container>
+              <Title>"id"</Title>
+              <Label>{&id()}</Label>
+            </Container>
+            <Container>
+              <Title>"address"</Title>
+              <Label>"bc1pyqz4gyra5cssfgawk6dunh4s9car9zrzpkw2l0sz4g9ym0cdxzescnf4u2"</Label>
+            </Container>
+            <Container>
+              <Title>"output value"</Title>
+              <Label>"546"</Label>
+            </Container>
+            <Container>
+              <Title>"sat"</Title>
+              <Label>"1862722370424422"</Label>
+            </Container>
+            <Container>
+              <Title>"content length"</Title>
+              <Label>"53 bytes"</Label>
+            </Container>
+            <Container>
+              <Title>"content type"</Title>
+              <Label>"text/plain;charset=utf-8"</Label>
+            </Container>
+            <Container>
+              <Title>"time stamp"</Title>
+              <Label>"2023-04-26 13:54:04 UTC"</Label>
+            </Container>
+            <Container>
+              <Title>"time stamp"</Title>
+              <Label>"2023-04-26 13:54:04 UTC"</Label>
+            </Container>
+            <Container>
+              <Title>"genesis height"</Title>
+              <Label>"787095"</Label>
+            </Container>
+            <Container>
+              <Title>"genesis fee"</Title>
+              <Label>"2448"</Label>
+            </Container>
+            <Container>
+              <Title>"genesis transaction"</Title>
+              <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c"</Label>
+            </Container>
+            <Container>
+              <Title>"location"</Title>
+              <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0:0"</Label>
+            </Container>
+            <Container>
+              <Title>"output"</Title>
+              <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0"</Label>
+            </Container>
+            <Container>
+              <Title>"offset"</Title>
+              <Label>"0"</Label>
+            </Container>
+          }.into_view(cx),
+        }
+      }
+    }
+    <A href="/" class="flex justify-center items-center ease text-gray-400 hover:text-gray-500 dark:text-gray-300 dark:hover:text-gray-200 p-4 my-5 text-md lg:text-xl">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 mr-1">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 9l-3 3m0 0l3 3m-3-3h7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    "Back"
+    </A>
     </div>
   }
 }

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -80,72 +80,67 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
                       <Title>"id"</Title>
                       <Label>{&id()}</Label>
                     </Container>
-                    <div class="text-white">{&isDev.to_string()}</div>
-
                     {if isDev {
-                      view! { cx,
-                        <Container>
-                          <Title>"address"</Title>
-                          <Label>"bc1pyqz4gyra5cssfgawk6dunh4s9car9zrzpkw2l0sz4g9ym0cdxzescnf4u2"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"output value"</Title>
-                          <Label>"546"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"sat"</Title>
-                          <Label>"1862722370424422"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"content length"</Title>
-                          <Label>"53 bytes"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"content type"</Title>
-                          <Label>"text/plain;charset=utf-8"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"time stamp"</Title>
-                          <Label>"2023-04-26 13:54:04 UTC"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"time stamp"</Title>
-                          <Label>"2023-04-26 13:54:04 UTC"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"genesis height"</Title>
-                          <Label>"787095"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"genesis fee"</Title>
-                          <Label>"2448"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"genesis transaction"</Title>
-                          <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"location"</Title>
-                          <Label>
-                            "a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0:0"
-                          </Label>
-                        </Container>
-                        <Container>
-                          <Title>"output"</Title>
-                          <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0"</Label>
-                        </Container>
-                        <Container>
-                          <Title>"offset"</Title>
-                          <Label>"0"</Label>
-                        </Container>
-                    }
-                  } else {
-                    view! { cx, <></>}
+                        view! { cx,
+                          <Container>
+                            <Title>"address"</Title>
+                            <Label>"bc1pyqz4gyra5cssfgawk6dunh4s9car9zrzpkw2l0sz4g9ym0cdxzescnf4u2"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"output value"</Title>
+                            <Label>"546"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"sat"</Title>
+                            <Label>"1862722370424422"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"content length"</Title>
+                            <Label>"53 bytes"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"content type"</Title>
+                            <Label>"text/plain;charset=utf-8"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"time stamp"</Title>
+                            <Label>"2023-04-26 13:54:04 UTC"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"time stamp"</Title>
+                            <Label>"2023-04-26 13:54:04 UTC"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"genesis height"</Title>
+                            <Label>"787095"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"genesis fee"</Title>
+                            <Label>"2448"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"genesis transaction"</Title>
+                            <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"location"</Title>
+                            <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0:0"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"output"</Title>
+                            <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0"</Label>
+                          </Container>
+                          <Container>
+                            <Title>"offset"</Title>
+                            <Label>"0"</Label>
+                          </Container>
+                        }
+                    } else {
+                        view! { cx, <></> }
+                    }}
                   }
-                }
-              }
                       .into_view(cx)
-            }
+              }
           }
       }}
       <A

--- a/src/app/routes/inscription.rs
+++ b/src/app/routes/inscription.rs
@@ -33,6 +33,11 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
   let hash = id.derive_signal(cx);
   let (fullscreen, set_fullscreen) = create_signal(cx, false);
 
+  let isDev = std::env::var("LEPTOS_ENV")
+    .unwrap_or("DEV".to_string())
+    .to_lowercase()
+    == "dev";
+
   view! { cx,
     <div class="content">
       {move || {
@@ -75,63 +80,72 @@ pub fn Inscription(cx: Scope) -> impl IntoView {
                       <Title>"id"</Title>
                       <Label>{&id()}</Label>
                     </Container>
-                    <Container>
-                      <Title>"address"</Title>
-                      <Label>"bc1pyqz4gyra5cssfgawk6dunh4s9car9zrzpkw2l0sz4g9ym0cdxzescnf4u2"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"output value"</Title>
-                      <Label>"546"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"sat"</Title>
-                      <Label>"1862722370424422"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"content length"</Title>
-                      <Label>"53 bytes"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"content type"</Title>
-                      <Label>"text/plain;charset=utf-8"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"time stamp"</Title>
-                      <Label>"2023-04-26 13:54:04 UTC"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"time stamp"</Title>
-                      <Label>"2023-04-26 13:54:04 UTC"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"genesis height"</Title>
-                      <Label>"787095"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"genesis fee"</Title>
-                      <Label>"2448"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"genesis transaction"</Title>
-                      <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"location"</Title>
-                      <Label>
-                        "a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0:0"
-                      </Label>
-                    </Container>
-                    <Container>
-                      <Title>"output"</Title>
-                      <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0"</Label>
-                    </Container>
-                    <Container>
-                      <Title>"offset"</Title>
-                      <Label>"0"</Label>
-                    </Container>
+                    <div class="text-white">{&isDev.to_string()}</div>
+
+                    {if isDev {
+                      view! { cx,
+                        <Container>
+                          <Title>"address"</Title>
+                          <Label>"bc1pyqz4gyra5cssfgawk6dunh4s9car9zrzpkw2l0sz4g9ym0cdxzescnf4u2"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"output value"</Title>
+                          <Label>"546"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"sat"</Title>
+                          <Label>"1862722370424422"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"content length"</Title>
+                          <Label>"53 bytes"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"content type"</Title>
+                          <Label>"text/plain;charset=utf-8"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"time stamp"</Title>
+                          <Label>"2023-04-26 13:54:04 UTC"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"time stamp"</Title>
+                          <Label>"2023-04-26 13:54:04 UTC"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"genesis height"</Title>
+                          <Label>"787095"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"genesis fee"</Title>
+                          <Label>"2448"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"genesis transaction"</Title>
+                          <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"location"</Title>
+                          <Label>
+                            "a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0:0"
+                          </Label>
+                        </Container>
+                        <Container>
+                          <Title>"output"</Title>
+                          <Label>"a5a6f451c8f0fbd150c05b4d75c7ac45281962f3c41079d2050cc78e78243f6c:0"</Label>
+                        </Container>
+                        <Container>
+                          <Title>"offset"</Title>
+                          <Label>"0"</Label>
+                        </Container>
+                    }
+                  } else {
+                    view! { cx, <></>}
                   }
-                      .into_view(cx)
+                }
               }
+                      .into_view(cx)
+            }
           }
       }}
       <A

--- a/src/app/routes/mod.rs
+++ b/src/app/routes/mod.rs
@@ -1,0 +1,5 @@
+pub mod home;
+pub mod inscription;
+
+pub use home::*;
+pub use inscription::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,12 +177,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 #[cfg(feature = "ssr")]
 // #[tracing::instrument]
 async fn spawn_app() {
-  use axum::{routing::get, Router};
   use axum_otel_metrics::HttpMetricsLayerBuilder;
   use tower_http::services::ServeDir;
   let metrics = HttpMetricsLayerBuilder::new().build();
 
-  crate::app::register_server_functions();
+  crate::app::functions::register_server_functions();
 
   // Setting this to None means we'll be using cargo-leptos and its env vars.
   // when not using cargo-leptos None must be replaced with Some("Cargo.toml")

--- a/src/server_actions.rs
+++ b/src/server_actions.rs
@@ -120,7 +120,7 @@ pub(crate) async fn tick_bitcoin_core(
       continue;
     }
 
-    let inscription_id = format!("{}i0", &txid);
+    let inscription_id = format!("{}", &txid);
     broadcast.push(inscription_id);
   }
 

--- a/src/style/input.css
+++ b/src/style/input.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+
+  .content {
+    @apply mx-auto max-w-7xl px-4 sm:px-6 lg:px-8;
+  }
+
+  .ease {
+    @apply transition duration-300 ease-in-out;
+  }
+}


### PR DESCRIPTION
- [x] Introduce `/` + `inscription/{id}` routes - contents goes into `app/routes`
- [x] Extract `Home` content from `App`
- [x] Extract + Rename `StreamValues` to `StreamContext`
- [x] Extract server functions from `App` into `app/functions/*`
- [x] Remove deprecated `count*` stuff (based on Leptos counter example)
- [x] Footer: Use `StreamContext` instead of passing props down
- [ ] ~~Add fetch inscriptions logic into `app/functions/api` incl. `Inscription` data structure~~ **Moved to** #109
- [x] Style `Inscription` component
- [x] Show preview in a layer (on-top)
- [x] Update styles in header + footer 
- [x] Fix #59 in 53aacfb 
- [x] Optimize release build by following [Appendix: Optimizing WASM Binary Size](https://leptos-rs.github.io/leptos/appendix_binary_size.html#things-to-do) and adding options for release build (66949ae)

## Preview

[Screencast from 26.04.2023 19:42:43.webm](https://user-images.githubusercontent.com/47693/234660150-e8131016-ef18-49a2-a00d-ebef500a519a.webm)

Closes #97
Fixes #59