### PR TITLE
I18nContext, reactive t(), locales de/en/hi/zn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,7 @@ dependencies = [
  "bitcoincore-rpc-json",
  "broadcaster",
  "cfg-if 1.0.0",
+ "common_macros",
  "console-subscriber",
  "console_error_panic_hook",
  "console_log",
@@ -2169,6 +2170,7 @@ dependencies = [
  "rusty-hook",
  "serde",
  "serde_json",
+ "strum",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3018,6 +3020,28 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bitcoincore-rpc = { version = "0.17.0", optional = true }
 bitcoincore-rpc-json = { version = "0.17.0", optional = true }
 broadcaster = "1"
 cfg-if = "1"
+common_macros = "0.1"
 console-subscriber = { version = "0.1.8", optional = true }
 console_error_panic_hook = "0.1"
 console_log = "1.0"
@@ -45,6 +46,7 @@ rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.11.17", optional = true, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
+strum = { version = "0.24", features = ["derive"] }
 thiserror = "1.0.40"
 tokio = { version = "1.28.0", features = ["full"], optional = true }
 tokio-stream = { version = "0.1.14", optional = true }

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use leptos_router::*;
 
 mod components;
 pub mod functions;
+pub mod i18n;
 mod providers;
 mod routes;
 
@@ -37,6 +38,7 @@ pub fn App(cx: Scope) -> impl IntoView {
   provide_meta_context(cx);
   provide_theme_context(cx);
   provide_stream_context(cx);
+  provide_i18n_context(cx);
 
   let theme_ctx = use_context::<ThemeContext>(cx).expect("Failed to get ThemeContext");
 

--- a/src/app/components/layout.rs
+++ b/src/app/components/layout.rs
@@ -1,6 +1,8 @@
 use crate::app::components::{ThemeToggle, ThemeToggleProps};
 use leptos::*;
 use leptos_router::*;
+use std::str::FromStr;
+use strum::IntoEnumIterator;
 
 use crate::app::providers::*;
 
@@ -68,6 +70,10 @@ pub fn Footer(cx: Scope) -> impl IntoView {
     ..
   } = use_context::<StreamContext>(cx).expect("Failed to get StreamContext");
 
+  let I18nContext {
+    locale: locale_rw, ..
+  } = use_context::<I18nContext>(cx).expect("Failed to get I18nContext");
+
   let current = move || match time.get() {
     None => String::from("--"),
     Some(v) => match v.duration_since(std::time::SystemTime::UNIX_EPOCH) {
@@ -123,6 +129,22 @@ pub fn Footer(cx: Scope) -> impl IntoView {
                 ></path>
               </svg>
             </a>
+            <select on:change=move |ev| {
+                let v = event_target_value(&ev);
+                let l = Locale::from_str(&v).unwrap();
+                locale_rw.set(l);
+            }>
+              {Locale::iter()
+                  .map(|locale| {
+                      let value_str: &'static str = locale.as_str();
+                      view! { cx,
+                        <option value=value_str selected=locale == locale_rw.get()>
+                          {locale.as_str()}
+                        </option>
+                      }
+                  })
+                  .collect::<Vec<_>>()}
+            </select>
           </div>
         </div>
       </div>

--- a/src/app/components/layout.rs
+++ b/src/app/components/layout.rs
@@ -1,4 +1,5 @@
 use crate::app::components::{ThemeToggle, ThemeToggleProps};
+use crate::app::i18n::{Locale, T};
 use leptos::*;
 use leptos_router::*;
 use std::str::FromStr;
@@ -8,6 +9,8 @@ use crate::app::providers::*;
 
 #[component]
 pub fn Header(cx: Scope) -> impl IntoView {
+  let i18n = use_context::<I18nContext>(cx).expect("Failed to get I18nContext");
+
   view! { cx,
     <header class="w-full">
       <nav class="bg-gray-800">
@@ -49,7 +52,7 @@ pub fn Header(cx: Scope) -> impl IntoView {
                       clip-rule="evenodd"
                     ></path>
                   </svg>
-                  "Fork on GitHub"
+                  {i18n.t(cx, T::ForkGH)}
                 </a>
               </div>
               <ThemeToggle/>
@@ -129,16 +132,19 @@ pub fn Footer(cx: Scope) -> impl IntoView {
                 ></path>
               </svg>
             </a>
-            <select on:change=move |ev| {
-                let v = event_target_value(&ev);
-                let l = Locale::from_str(&v).unwrap();
-                locale_rw.set(l);
-            }>
+            <select
+              class="focus:ring-0 border-0 background text-gray-400 bg-white dark:bg-slate-800"
+              on:change=move |ev| {
+                  let v = event_target_value(&ev);
+                  let l = Locale::from_str(&v).unwrap();
+                  locale_rw.set(l);
+              }
+            >
               {Locale::iter()
                   .map(|locale| {
-                      let value_str: &'static str = locale.as_str();
+                      let value: &'static str = locale.as_str();
                       view! { cx,
-                        <option value=value_str selected=locale == locale_rw.get()>
+                        <option value=value selected=locale == locale_rw.get()>
                           {locale.as_str()}
                         </option>
                       }

--- a/src/app/i18n/de.rs
+++ b/src/app/i18n/de.rs
@@ -1,0 +1,11 @@
+use crate::app::providers::i18n::{Translation, TK};
+
+use common_macros::hash_map;
+
+#[allow(dead_code)]
+pub fn translation() -> Translation {
+  hash_map!(
+      TK::Hello => "Hallo",
+      TK::World => "Welt",
+  )
+}

--- a/src/app/i18n/de.rs
+++ b/src/app/i18n/de.rs
@@ -1,11 +1,11 @@
-use crate::app::providers::i18n::{Translation, TK};
-
 use common_macros::hash_map;
+
+use super::types::{Translation, T};
 
 #[allow(dead_code)]
 pub fn translation() -> Translation {
   hash_map!(
-      TK::Hello => "Hallo",
-      TK::World => "Welt",
+      T::HomeTitle => "Erwartete Inschriften",
+      T::ForkGH => "Fork bei GitHub",
   )
 }

--- a/src/app/i18n/en.rs
+++ b/src/app/i18n/en.rs
@@ -1,0 +1,11 @@
+use crate::app::providers::i18n::{Translation, TK};
+
+use common_macros::hash_map;
+
+#[allow(dead_code)]
+pub fn translation() -> Translation {
+  hash_map!(
+      TK::Hello => "hello",
+      TK::World => "world",
+  )
+}

--- a/src/app/i18n/hi.rs
+++ b/src/app/i18n/hi.rs
@@ -1,0 +1,10 @@
+use common_macros::hash_map;
+
+use super::types::{Translation, T};
+
+pub fn translation() -> Translation {
+  hash_map!(
+    T::HomeTitle => "अपेक्षित अभिलेख",
+    T::ForkGH => "गिटहब पर फोर्क",
+  )
+}

--- a/src/app/i18n/mod.rs
+++ b/src/app/i18n/mod.rs
@@ -1,14 +1,18 @@
-use crate::app::providers::i18n::Locale;
-
-use super::providers::Translation;
-
 mod de;
 mod en;
+mod hi;
+mod zn;
+
+mod types;
+
+pub use types::*;
 
 #[allow(dead_code)]
-pub fn locale_data(l: Locale) -> Translation {
+pub fn translation(l: Locale) -> Translation {
   match l {
     Locale::DE => de::translation(),
     Locale::EN => en::translation(),
+    Locale::ZN => zn::translation(),
+    Locale::HI => hi::translation(),
   }
 }

--- a/src/app/i18n/mod.rs
+++ b/src/app/i18n/mod.rs
@@ -1,0 +1,14 @@
+use crate::app::providers::i18n::Locale;
+
+use super::providers::Translation;
+
+mod de;
+mod en;
+
+#[allow(dead_code)]
+pub fn locale_data(l: Locale) -> Translation {
+  match l {
+    Locale::DE => de::translation(),
+    Locale::EN => en::translation(),
+  }
+}

--- a/src/app/i18n/types.rs
+++ b/src/app/i18n/types.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+use strum::{EnumIter, EnumString};
+
+#[allow(dead_code)]
+#[derive(Clone, EnumIter, EnumString, Debug, PartialEq, Eq, Default)]
+pub enum Locale {
+  #[default]
+  EN,
+  DE,
+  ZN,
+  HI,
+}
+
+impl Locale {
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      Locale::EN => "EN",
+      Locale::DE => "DE",
+      Locale::ZN => "ZN",
+      Locale::HI => "HI",
+    }
+  }
+}
+
+// T = Translation Key
+#[derive(Eq, PartialEq, Clone, Hash, Debug)]
+pub enum T {
+  HomeTitle,
+  ForkGH,
+}
+
+pub type Translation = HashMap<T, &'static str>;

--- a/src/app/i18n/zn.rs
+++ b/src/app/i18n/zn.rs
@@ -2,10 +2,9 @@ use common_macros::hash_map;
 
 use super::types::{Translation, T};
 
-#[allow(dead_code)]
 pub fn translation() -> Translation {
   hash_map!(
-    T::HomeTitle => "Anticipated inscriptions",
-    T::ForkGH => "Fork on GitHub",
+    T::HomeTitle => "預期的銘文",
+    T::ForkGH => "在GitHub上派生",
   )
 }

--- a/src/app/providers/i18n.rs
+++ b/src/app/providers/i18n.rs
@@ -1,33 +1,6 @@
 use leptos::*;
-use std::collections::HashMap;
-use strum::{EnumIter, EnumString};
 
-use crate::app::i18n::locale_data;
-
-#[allow(dead_code)]
-#[derive(Clone, EnumIter, EnumString, Debug, PartialEq, Eq)]
-pub enum Locale {
-  EN,
-  DE,
-}
-
-impl Locale {
-  pub fn as_str(&self) -> &'static str {
-    match self {
-      Locale::EN => "EN",
-      Locale::DE => "DE",
-    }
-  }
-}
-
-pub type Translation = HashMap<TK, &'static str>;
-
-// TK = Translation Key
-#[derive(Eq, PartialEq, Clone, Hash, Debug)]
-pub enum TK {
-  Hello,
-  World,
-}
+use crate::app::i18n::{translation, Locale, T};
 
 #[allow(dead_code)]
 #[derive(Clone)]
@@ -41,10 +14,10 @@ impl I18nContext {
     Self { locale }
   }
 
-  pub fn t(self, cx: Scope, key: TK) -> Memo<String> {
+  pub fn t(self, cx: Scope, key: T) -> Memo<String> {
     create_memo(cx, move |_| {
       let l = self.locale.get();
-      if let Some(val) = locale_data(l).get(&key) {
+      if let Some(val) = translation(l).get(&key) {
         val.to_string()
       } else {
         debug_warn!("(i18n::t) key not found: {:?}", key);
@@ -56,6 +29,6 @@ impl I18nContext {
 
 pub fn provide_i18n_context(cx: Scope) {
   if use_context::<I18nContext>(cx).is_none() {
-    provide_context(cx, I18nContext::new(cx, Locale::EN));
+    provide_context(cx, I18nContext::new(cx, Locale::default()));
   }
 }

--- a/src/app/providers/i18n.rs
+++ b/src/app/providers/i18n.rs
@@ -1,0 +1,61 @@
+use leptos::*;
+use std::collections::HashMap;
+use strum::{EnumIter, EnumString};
+
+use crate::app::i18n::locale_data;
+
+#[allow(dead_code)]
+#[derive(Clone, EnumIter, EnumString, Debug, PartialEq, Eq)]
+pub enum Locale {
+  EN,
+  DE,
+}
+
+impl Locale {
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      Locale::EN => "EN",
+      Locale::DE => "DE",
+    }
+  }
+}
+
+pub type Translation = HashMap<TK, &'static str>;
+
+// TK = Translation Key
+#[derive(Eq, PartialEq, Clone, Hash, Debug)]
+pub enum TK {
+  Hello,
+  World,
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(crate) struct I18nContext {
+  pub locale: RwSignal<Locale>,
+}
+
+impl I18nContext {
+  pub fn new(cx: Scope, l: Locale) -> Self {
+    let locale = create_rw_signal(cx, l);
+    Self { locale }
+  }
+
+  pub fn t(self, cx: Scope, key: TK) -> Memo<String> {
+    create_memo(cx, move |_| {
+      let l = self.locale.get();
+      if let Some(val) = locale_data(l).get(&key) {
+        val.to_string()
+      } else {
+        debug_warn!("(i18n::t) key not found: {:?}", key);
+        format!("{:?}", key)
+      }
+    })
+  }
+}
+
+pub fn provide_i18n_context(cx: Scope) {
+  if use_context::<I18nContext>(cx).is_none() {
+    provide_context(cx, I18nContext::new(cx, Locale::EN));
+  }
+}

--- a/src/app/providers/mod.rs
+++ b/src/app/providers/mod.rs
@@ -1,5 +1,7 @@
+pub mod i18n;
 pub mod stream;
 pub mod theme;
 
+pub use i18n::*;
 pub use stream::*;
 pub use theme::*;

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -7,6 +7,7 @@ pub fn Home(cx: Scope) -> impl IntoView {
   let StreamContext {
     info, inscription, ..
   } = use_context::<StreamContext>(cx).expect("Failed to get StreamContext");
+  let i18n = use_context::<I18nContext>(cx).expect("Failed to get I18nContext");
 
   let initial_inscriptions: Vec<_> = (0..6).map(|n| format!("punk_{}.webp", n)).collect();
 
@@ -14,7 +15,7 @@ pub fn Home(cx: Scope) -> impl IntoView {
     <div class="content py-8">
       <div class="flex">
         <h1 class="flex-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
-          "Live unconfirmed inscriptions"
+          "Live unconfirmed inscriptions " {i18n.t(cx, TK::Hello)}
         </h1>
       </div>
       <div class="text-xs text-gray-900 dark:text-gray-100 empty:after:content-['\u{200b}'] empty:after:inline-block">

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -1,4 +1,5 @@
 use crate::app::components::*;
+use crate::app::i18n::T;
 use crate::app::providers::*;
 use leptos::*;
 
@@ -14,9 +15,9 @@ pub fn Home(cx: Scope) -> impl IntoView {
   view! { cx,
     <div class="content py-8">
       <div class="flex">
-        <h1 class="flex-1 text-2xl font-bold text-gray-900 dark:text-gray-100">
-          "Live unconfirmed inscriptions " {i18n.t(cx, TK::Hello)}
-        </h1>
+        <h1 class="flex items-center text-2xl font-bold text-gray-900 dark:text-gray-100
+        before:mr-2 before:block before:w-6 before:h-6 before:border-4 before:rounded-full before:border-red-500 mr-2
+        ">{i18n.t(cx, T::HomeTitle)}</h1>
       </div>
       <div class="text-xs text-gray-900 dark:text-gray-100 empty:after:content-['\u{200b}'] empty:after:inline-block">
         {info}


### PR DESCRIPTION
- [x] `I18nContext`
- [x] Reactive `t()`
- [x] Locales de/en
- [x] Add locales from #123

[Screencast from 10.05.2023 10:40:18.webm](https://github.com/ordilabs/live/assets/47693/388bc8a9-82aa-4928-8de5-927f116a77c8)



Close #125 