### PR TITLE
Fix release build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,9 +1396,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.62"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3564,9 +3564,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.85"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3574,16 +3574,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.85"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -3601,9 +3601,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.85"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3611,28 +3611,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.85"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.85"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.62"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tracing-subscriber = { version = "0.3.17", features = [
   "env-filter",
 ], optional = true }
 wasm-bindgen = "0.2"
-web-sys = { version = "0.3.62", features = ["HtmlDocument"] }
+web-sys = { version = "0.3.61", features = ["HtmlDocument"] }
 
 [dev-dependencies]
 rusty-hook = "^0.11.2"

--- a/src/app/providers/i18n.rs
+++ b/src/app/providers/i18n.rs
@@ -61,13 +61,14 @@ impl I18nContext {
       if let Some(val) = translation(l).get(&key) {
         val.to_string()
       } else {
-        debug_warn!("(i18n::t) key not found: {:?}", key);
+        debug_warn!("(i18n::t) key not found: {:?}", &key);
         format!("{:?}", key)
       }
     })
   }
 }
 
+#[allow(dead_code)]
 pub fn provide_i18n_context(cx: Scope) {
   if use_context::<I18nContext>(cx).is_none() {
     let initial = initial_locale(cx);


### PR DESCRIPTION
- [x] `key` needs to be a reference
- [x] Revert changes of #131 + #130

Build should run as follow:
```bash
cargo clean
[...]

just build-release
[...]

cargo leptos serve --release
    Finished wasm-release [optimized] target(s) in 0.09s
       Cargo finished cargo build --package=ordilabs_live --lib --target-dir=target/front --target=wasm32-unknown-unknown --no-default-features --features=hydrate --profile=wasm-release
    Tailwind finished tailwind --input ./src/style/input.css --config ./src/style/tailwind.config.js
    Finished release [optimized] target(s) in 0.12s
       Cargo finished cargo build --package=ordilabs_live --bin=ordilabs_live --target-dir=target/server --no-default-features --features=ssr --release
2023-05-10T15:01:09.135085Z  INFO ordilabs_live: backend_bitcoin_core=BitcoinCore { auth: CookieFile("docker/bitcoin.cookie"), root: "127.0.0.1:18443" }
2023-05-10T15:01:09.136745Z  INFO ordilabs_live::server_actions: block_count=103
tick: bitcoin_core, 0, 0, 0, 369, 0
[...]
```

Fixes #120