### PR TITLE
macro `t!`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use leptos_router::*;
 
 mod components;
 pub mod functions;
+#[macro_use]
 pub mod i18n;
 mod providers;
 mod routes;

--- a/src/app/components/footer.rs
+++ b/src/app/components/footer.rs
@@ -1,4 +1,4 @@
-use crate::app::i18n::Locale;
+use crate::app::i18n::{I18nContext, Locale};
 use leptos::*;
 use leptos_router::*;
 use strum::IntoEnumIterator;

--- a/src/app/components/header.rs
+++ b/src/app/components/header.rs
@@ -1,12 +1,11 @@
 use crate::app::components::{ThemeToggle, ThemeToggleProps};
-use crate::app::i18n::{I18nContext, T};
+use crate::app::i18n::T;
+use crate::t;
 use leptos::*;
 use leptos_router::*;
 
 #[component]
 pub fn Header(cx: Scope) -> impl IntoView {
-  let i18n = use_context::<I18nContext>(cx).expect("Failed to get I18nContext");
-
   view! { cx,
     <header class="w-full">
       <nav class="bg-gray-800">
@@ -48,7 +47,7 @@ pub fn Header(cx: Scope) -> impl IntoView {
                       clip-rule="evenodd"
                     ></path>
                   </svg>
-                  {i18n.t(cx, T::ForkGH)}
+                  {t!(cx, T::ForkGH)}
                 </a>
               </div>
               <ThemeToggle/>

--- a/src/app/components/header.rs
+++ b/src/app/components/header.rs
@@ -1,9 +1,7 @@
 use crate::app::components::{ThemeToggle, ThemeToggleProps};
-use crate::app::i18n::T;
+use crate::app::i18n::{I18nContext, T};
 use leptos::*;
 use leptos_router::*;
-
-use crate::app::providers::*;
 
 #[component]
 pub fn Header(cx: Scope) -> impl IntoView {

--- a/src/app/i18n/context.rs
+++ b/src/app/i18n/context.rs
@@ -1,0 +1,39 @@
+use leptos::*;
+
+use crate::app::functions::SetLocale;
+
+use super::{
+  translation,
+  types::{Locale, T},
+};
+
+pub type SetLocaleAction = Action<SetLocale, Result<Locale, ServerFnError>>;
+
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+pub(crate) struct I18nContext {
+  pub locale: Signal<Locale>,
+  pub set_locale_action: SetLocaleAction,
+}
+
+#[allow(dead_code)]
+impl I18nContext {
+  pub fn new(locale: Signal<Locale>, set_locale_action: SetLocaleAction) -> Self {
+    Self {
+      locale,
+      set_locale_action,
+    }
+  }
+
+  pub fn t(self, cx: Scope, key: T) -> Memo<String> {
+    create_memo(cx, move |_| {
+      let l = self.locale.get();
+      if let Some(val) = translation(l).get(&key) {
+        val.to_string()
+      } else {
+        debug_warn!("(i18n::t) key not found: {:?}", &key);
+        format!("{:?}", key)
+      }
+    })
+  }
+}

--- a/src/app/i18n/context.rs
+++ b/src/app/i18n/context.rs
@@ -2,9 +2,12 @@ use leptos::*;
 
 use crate::app::functions::SetLocale;
 
+use std::option::Option;
+
 use super::{
   translation,
   types::{Locale, T},
+  TranslationArgs,
 };
 
 pub type SetLocaleAction = Action<SetLocale, Result<Locale, ServerFnError>>;
@@ -16,6 +19,15 @@ pub(crate) struct I18nContext {
   pub set_locale_action: SetLocaleAction,
 }
 
+pub fn replace(trans: String, args: &TranslationArgs) -> String {
+  let mut trans = trans;
+  for (&k, v) in args.iter() {
+    // Replace `${<k>}` -> `v`
+    trans = trans.replace(&format!("{{${}}}", k), v);
+  }
+  trans.to_owned()
+}
+
 #[allow(dead_code)]
 impl I18nContext {
   pub fn new(locale: Signal<Locale>, set_locale_action: SetLocaleAction) -> Self {
@@ -25,15 +37,66 @@ impl I18nContext {
     }
   }
 
-  pub fn t(self, cx: Scope, key: T) -> Memo<String> {
-    create_memo(cx, move |_| {
-      let l = self.locale.get();
-      if let Some(val) = translation(l).get(&key) {
-        val.to_string()
-      } else {
-        debug_warn!("(i18n::t) key not found: {:?}", &key);
-        format!("{:?}", key)
+  pub fn translate(self, cx: Scope, t: T, args: Option<TranslationArgs>) -> Memo<String> {
+    create_memo(cx, move |_| match translation(self.locale.get()).get(&t) {
+      Some(&trans) => {
+        let mut trans = trans.to_string();
+        if let Some(args) = &args {
+          trans = replace(trans.clone(), args);
+        }
+        trans.to_string()
+      }
+      None => {
+        debug_warn!("(i18n::t) key not found: {:?}", &t);
+        format!("{:?}", t)
       }
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::HashMap;
+
+  use crate::app::i18n::replace;
+  use common_macros::hash_map;
+
+  #[test]
+  fn replace_one_arg() {
+    let t = "hello {$name}".to_string();
+    let h = hash_map! {"name" => "world".to_string()};
+    let result = replace(t, &h);
+    assert_eq!(result, "hello world");
+  }
+
+  #[test]
+  fn replace_two_args() {
+    let t = "hello {$1} and {$2}".to_string();
+    let h = hash_map! {"1" => "Bob".to_string(), "2" => "Alice".to_string()};
+    let result = replace(t, &h);
+    assert_eq!(result, "hello Bob and Alice");
+  }
+
+  #[test]
+  fn replace_wrong_param() {
+    let t = "hello {$name}".to_string();
+    let h = hash_map! {"unkown" => "bbbr".to_string()};
+    let result = replace(t, &h);
+    assert_eq!(result, "hello {$name}");
+  }
+
+  #[test]
+  fn replace_empty_map() {
+    let t = "hello {$name}".to_string();
+    let result = replace(t, &HashMap::new());
+    assert_eq!(result, "hello {$name}");
+  }
+
+  #[test]
+  fn replace_nothing() {
+    let t = "hello".to_string();
+    let h = hash_map! {"name" => "world".to_string()};
+    let result = replace(t, &h);
+    assert_eq!(result, "hello");
   }
 }

--- a/src/app/i18n/mod.rs
+++ b/src/app/i18n/mod.rs
@@ -8,6 +8,7 @@ mod zh_hant;
 mod types;
 
 pub use context::*;
+use leptos::{use_context, Memo, Scope};
 pub use types::*;
 
 #[allow(dead_code)]
@@ -19,4 +20,57 @@ pub fn translation(l: Locale) -> Translation {
     Locale::ZnHant => zh_hant::translation(),
     Locale::Hi => hi::translation(),
   }
+}
+
+#[allow(dead_code)]
+pub fn t_macro(cx: Scope, t: T) -> Memo<String> {
+  let i18n: I18nContext = use_context::<I18nContext>(cx).expect("Failed to get I18nContext");
+  i18n.translate(cx, t, None)
+}
+
+#[allow(dead_code)]
+pub fn t_macro_with_args(cx: Scope, t: T, args: TranslationArgs) -> Memo<String> {
+  let i18n: I18nContext = use_context::<I18nContext>(cx).expect("Failed to get I18nContext");
+  i18n.translate(cx, t, Some(args))
+}
+
+/// `t!` macro
+///
+/// # Arguments
+///
+/// * `cx` - Scope
+/// * `t` - T (key of `Locale`)
+/// * `args` - `{key = value}` (optional) - Optional `args` will fill placeholders in translations
+///
+/// # Examples
+///
+/// ```
+/// use crate::t;
+///
+/// <div>{t!(cx, T::HomeTitle)}</div>
+///
+/// <h2>{move || {
+///    
+///    let a = "Alice".to_string();
+///    let b = "Bob".to_string();
+///    t!(cx, T::Hello, { "name_a" = a, "name_b" = "b" })
+///    // Given T::Hello = "Hello {a} and {b}" output will be `Hello Alice and Bob`
+/// </h2>
+/// ```
+#[macro_export]
+macro_rules! t {
+    // NO arguments
+    ($cx:expr, $t:path) => {
+        crate::app::i18n::t_macro($cx, $t)
+    };
+    // WITH ARGs
+    ($cx:expr, $t:path, {
+        $($key:literal = $value:expr),+
+    }) => {{
+        let mut args: TranslationArgs = std::collections::HashMap::new();
+        $(
+            args.insert($key, $value);
+        )+
+        crate::app::i18n::t_macro_with_args($cx, $t, args)
+    }};
 }

--- a/src/app/i18n/mod.rs
+++ b/src/app/i18n/mod.rs
@@ -1,3 +1,4 @@
+mod context;
 mod de;
 mod en;
 mod hi;
@@ -6,6 +7,7 @@ mod zh_hant;
 
 mod types;
 
+pub use context::*;
 pub use types::*;
 
 #[allow(dead_code)]

--- a/src/app/i18n/types.rs
+++ b/src/app/i18n/types.rs
@@ -54,3 +54,5 @@ pub enum T {
 }
 
 pub type Translation = HashMap<T, &'static str>;
+
+pub type TranslationArgs = HashMap<&'static str, String>;

--- a/src/app/providers/i18n.rs
+++ b/src/app/providers/i18n.rs
@@ -1,7 +1,7 @@
-use crate::app::functions::SetLocale;
 use leptos::*;
 
-use crate::app::i18n::{translation, Locale, T};
+use crate::app::functions::SetLocale;
+use crate::app::i18n::{I18nContext, Locale};
 
 #[allow(dead_code)]
 #[cfg(not(feature = "ssr"))]
@@ -35,37 +35,6 @@ fn initial_locale(cx: Scope) -> Locale {
         .and_then(|c| Locale::from_str(&c.value()).ok());
     })
     .unwrap_or_default()
-}
-
-type SetLocaleAction = Action<SetLocale, Result<Locale, ServerFnError>>;
-
-#[allow(dead_code)]
-#[derive(Clone, Copy)]
-pub(crate) struct I18nContext {
-  pub locale: Signal<Locale>,
-  pub set_locale_action: SetLocaleAction,
-}
-
-#[allow(dead_code)]
-impl I18nContext {
-  pub fn new(locale: Signal<Locale>, set_locale_action: SetLocaleAction) -> Self {
-    Self {
-      locale,
-      set_locale_action,
-    }
-  }
-
-  pub fn t(self, cx: Scope, key: T) -> Memo<String> {
-    create_memo(cx, move |_| {
-      let l = self.locale.get();
-      if let Some(val) = translation(l).get(&key) {
-        val.to_string()
-      } else {
-        debug_warn!("(i18n::t) key not found: {:?}", &key);
-        format!("{:?}", key)
-      }
-    })
-  }
 }
 
 #[allow(dead_code)]

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -1,5 +1,5 @@
 use crate::app::components::*;
-use crate::app::i18n::{I18nContext, T};
+use crate::app::i18n::T;
 use crate::app::providers::*;
 use crate::types::MempoolAllInfo;
 use leptos::*;
@@ -10,7 +10,6 @@ pub fn Home(cx: Scope) -> impl IntoView {
   let StreamContext {
     info, inscription, ..
   } = use_context::<StreamContext>(cx).expect("Failed to get StreamContext");
-  let i18n = use_context::<I18nContext>(cx).expect("Failed to get I18nContext");
 
   let infos = create_memo::<MempoolAllInfo>(cx, move |_| info().unwrap_or(Vec::new()));
 
@@ -88,7 +87,7 @@ pub fn Home(cx: Scope) -> impl IntoView {
       <div class="flex">
         <h1 class="flex items-center text-2xl font-bold text-gray-900 dark:text-gray-100
         before:mr-2 before:block before:w-6 before:h-6 before:border-4 before:rounded-full before:border-red-500 mr-2 mb-4
-        ">{i18n.clone().t(cx, T::HomeTitle)}</h1>
+        ">{t!(cx, T::HomeTitle)}</h1>
       </div>
       <div class="flex flex-wrap text-base text-gray-600 dark:text-gray-100">
         <Show
@@ -112,7 +111,10 @@ pub fn Home(cx: Scope) -> impl IntoView {
               view=move |cx, m| {
                   let icon = move || get_icon(cx, &m.media);
                   let count = move || format!("{}", m.count);
-                  let label = move || i18n.clone().t(cx, get_label(&m.media, m.count));
+                  let label = move || {
+                      let l = get_label(&m.media, m.count);
+                      t!(cx, l)
+                  };
                   let size = move || format!("({:.1} kB)", m.size as f64 / 1024.0);
                   view! { cx,
                     <div class="flex items-center pl-2 pr-4">

--- a/src/app/routes/home.rs
+++ b/src/app/routes/home.rs
@@ -1,5 +1,5 @@
 use crate::app::components::*;
-use crate::app::i18n::T;
+use crate::app::i18n::{I18nContext, T};
 use crate::app::providers::*;
 use crate::types::MempoolAllInfo;
 use leptos::*;


### PR DESCRIPTION
to simplify/improve `i18n` rendering.

## Example

```rust
// Given following translation
// T::title => "Any Title",
// T::Hello => "Hello {$name}",

// No extra args (default)
<div>{t!(cx, T::Title)}</div> // Output: "Any Title"

// Additional args
<h2>{move || {
  let name = "World".to_string();
  t!(cx, T::Hello, { "name" = name })
</h2> // Output: "Hello World"


```

Highly inspired by [Perseus'  Internationalization](https://framesurge.sh/perseus/en-US/docs/0.4.x/fundamentals/i18n/) approach - code: [`macro t!` ](https://github.com/framesurge/perseus/blob/be75ac48c7fb01768c38e0f7d7a593e38ed65c9b/packages/perseus/src/translator/mod.rs#L102-L119), [`t_macro_backend`](https://github.com/framesurge/perseus/blob/be75ac48c7fb01768c38e0f7d7a593e38ed65c9b/packages/perseus/src/translator/lightweight.rs#L148-L153), [`t_macro_backend_with_args`](https://github.com/framesurge/perseus/blob/be75ac48c7fb01768c38e0f7d7a593e38ed65c9b/packages/perseus/src/translator/lightweight.rs#L157-L162), [`translate_checked`](https://github.com/framesurge/perseus/blob/be75ac48c7fb01768c38e0f7d7a593e38ed65c9b/packages/perseus/src/translator/lightweight.rs#L93-L115) - but more simplified for our use case.

In addition: Extract _I18nContext_ (no change here, just to reduce "complexity" in `providers`) 403fb3b6faaec06c23fb423ddbbcdf232e832a62 - we might do it similar for other providers.