### PR TITLE
Fix: Remove `block_count` from `tick_inscription`

### DIFF
--- a/src/server_actions.rs
+++ b/src/server_actions.rs
@@ -25,13 +25,6 @@ pub(crate) async fn tick_inscriptions(
   backend: &BitcoinCore,
   ordipool: &mut HashMap<String, Option<Inscription>>,
 ) {
-  // Current block
-  let block_count = backend.get_block_count().await;
-  tracing::info!(?block_count);
-
-  let event = LiveEvent::BlockCount(block_count);
-  _ = EVENT_CHANNEL.send(&event).await;
-
   let tick_start = std::time::Instant::now();
 
   let mpr = backend.recent().await.ok();


### PR DESCRIPTION
to call it in `tick_blockinfo` only. Already done in  #154, but reverted by accident in 1121a27 .