### PR TITLE
Relax dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: daily
-  - package-ecosystem: cargo
-    directory: /
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: [version-update:semver-patch]
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
-      interval: daily
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: [version-update:semver-patch]


### PR DESCRIPTION
Check `weekly` and `major/minor` versions only

Reference:
- `interval` https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval
- `ignore` https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore